### PR TITLE
Pass grammar to propagators

### DIFF
--- a/src/comesafter.jl
+++ b/src/comesafter.jl
@@ -13,7 +13,7 @@ ComesAfter(rule::Int, predecessor::Int) = ComesAfter(rule, [predecessor])
 Propagates the ComesAfter constraint.
 It removes the rule from the domain if the predecessors sequence is in the ancestors.
 """
-function propagate(c::ComesAfter, context::GrammarContext, domain::Vector{Int})
+function propagate(c::ComesAfter, ::Grammar, context::GrammarContext, domain::Vector{Int})
 	ancestors = get_rulesequence(context.originalExpr, context.nodeLocation[begin:end-1])  # remove the current node from the node sequence
 	if c.rule in domain  # if rule is in domain, check the ancestors
 		if Grammars.containedin(c.predecessors, ancestors)

--- a/src/forbidden.jl
+++ b/src/forbidden.jl
@@ -11,7 +11,7 @@ end
 Propagates the Forbidden constraint.
 It removes the elements from the domain that would complete the forbidden sequence.
 """
-function propagate(c::Forbidden, context::GrammarContext, domain::Vector{Int})
+function propagate(c::Forbidden, context::GrammarContext, ::Grammar, domain::Vector{Int})
 	ancestors = get_rulesequence(context.originalExpr, context.nodeLocation[begin:end-1])
 	
 	if Grammars.subsequenceof(c.sequence[begin:end-1], ancestors)

--- a/src/ordered.jl
+++ b/src/ordered.jl
@@ -12,7 +12,7 @@ Propagates the Ordered constraint.
 It removes every element from the domain that does not have a necessary 
 predecessor in the left subtree.
 """
-function propagate(c::Ordered, context::GrammarContext, domain::Vector{Int})
+function propagate(c::Ordered, context::GrammarContext, ::Grammar, domain::Vector{Int})
 	rules_on_left = rulesonleft(context.originalExpr, context.nodeLocation)
 	
 	last_rule_index = 0


### PR DESCRIPTION
Sometimes propagators need access to the grammar to e.g. check if a rule corresponds to a variable or is terminal.

Corresponding PR in Search.jl:
- https://github.com/Herb-AI/Search.jl/pull/11
