### PR TITLE
Disjunctive constraint

### DIFF
--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -17,9 +17,11 @@ include("propagatorconstraints/forbidden_path.jl")
 include("propagatorconstraints/ordered_path.jl")
 include("propagatorconstraints/forbidden.jl")
 include("propagatorconstraints/ordered.jl")
+include("propagatorconstraints/disjunctive.jl")
 
 include("localconstraints/local_forbidden.jl")
 include("localconstraints/local_ordered.jl")
+include("localconstraints/local_disjunctive.jl")
 
 export
     AbstractMatchNode,
@@ -44,8 +46,10 @@ export
     OrderedPath,
     Forbidden,
     Ordered,
+    Disjunctive,
 
     LocalForbidden,
-    LocalOrdered
+    LocalOrdered,
+    LocalDisjunctive
 
 end # module HerbConstraints

--- a/src/localconstraints/local_disjunctive.jl
+++ b/src/localconstraints/local_disjunctive.jl
@@ -1,0 +1,41 @@
+# include("../HerbConstraints.jl")
+
+"""
+Meta-constraint that enforces the disjunction of its given constraints.
+"""
+mutable struct LocalDisjunctive <: LocalConstraint
+    first::PropagatorConstraint
+    second::PropagatorConstraint
+end
+
+
+"""
+Propagates the LocalDisjunctive constraint.
+It enforces that at least one of its given constraints hold.
+"""
+function propagate(c::LocalDisjunctive, g::Grammar, context::GrammarContext, domain::Vector{Int})::Tuple{Vector{Int}, Vector{LocalConstraint}}
+    # Propagate the two member propagators
+    first_new_domain, first_new_constraints = propagate(c.first, g, context, copy(domain))
+    second_new_domain, second_new_constraints = propagate(c.second, g, context, copy(domain))
+
+    # Take the union of the two resulting domains
+    new_domains::Vector{Int} = unique!([first_new_domain; second_new_domain])
+    
+    # Return itself if neither were removed
+    if first_new_constraints != [] && second_new_constraints != []
+        return new_domains, [c]
+    end
+
+    # return the first constraint if it was not removed
+    if first_new_constraints != []
+        return new_domains, c.first
+    end
+
+    # return the second constraint if it was not removed
+    if second_new_constraints != []
+        return new_domains, c.second
+    end
+
+    # return no remaining constraints if both were removed
+    return new_domains, []
+end

--- a/src/propagatorconstraints/disjunctive.jl
+++ b/src/propagatorconstraints/disjunctive.jl
@@ -2,16 +2,21 @@
 Meta-constraint that enforces the disjunction of its given constraints.
 """
 struct Disjunctive <: PropagatorConstraint
-    first::PropagatorConstraint
-    second::PropagatorConstraint
+    constraints::Vector{PropagatorConstraint}
 end
+
+
+# Varargs constructors
+function Disjunctive(constraint::PropagatorConstraint) return Disjunctive([constraint]) end
+function Disjunctive(constraints...) return Disjunctive([constraints...]) end
+
 
 """
 Propagates the Disjunctive constraint.
 It enforces that at least one of its given constraints hold.
 """
 function propagate(c::Disjunctive, g::Grammar, context::GrammarContext, domain::Vector{Int})::Tuple{Vector{Int}, Vector{LocalConstraint}}
-    disjunctive_constraint = LocalDisjunctive(c.first, c.second)
+    disjunctive_constraint = LocalDisjunctive(c.constraints)
     new_domain, new_constraints = propagate(disjunctive_constraint, g, context, domain)
     return new_domain, new_constraints
 end

--- a/src/propagatorconstraints/disjunctive.jl
+++ b/src/propagatorconstraints/disjunctive.jl
@@ -1,0 +1,17 @@
+"""
+Meta-constraint that enforces the disjunction of its given constraints.
+"""
+struct Disjunctive <: PropagatorConstraint
+    first::PropagatorConstraint
+    second::PropagatorConstraint
+end
+
+"""
+Propagates the Disjunctive constraint.
+It enforces that at least one of its given constraints hold.
+"""
+function propagate(c::Disjunctive, g::Grammar, context::GrammarContext, domain::Vector{Int})::Tuple{Vector{Int}, Vector{LocalConstraint}}
+    disjunctive_constraint = LocalDisjunctive(c.first, c.second)
+    new_domain, new_constraints = propagate(disjunctive_constraint, g, context, domain)
+    return new_domain, new_constraints
+end


### PR DESCRIPTION
This PR adds a disjunctive constraint.
This allows the user to specify multiple constraints, for which the disjunction of their propagators is evaluated.