### PR TITLE
Solver using kwargs for max depth and max size

### DIFF
--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -96,6 +96,7 @@ export
     get_state,
     get_tree,
     get_grammar,
+    get_starting_symbol,
     get_state,
     get_node_at_location,
     get_hole_at_location,

--- a/src/solver/generic_solver/generic_solver.jl
+++ b/src/solver/generic_solver/generic_solver.jl
@@ -30,9 +30,9 @@ end
 
 Constructs a new solver, with an initial state using starting symbol `sym`
 """
-function GenericSolver(grammar::AbstractGrammar, sym::Symbol; with_statistics=false, use_uniformsolver=true)
+function GenericSolver(grammar::AbstractGrammar, sym::Symbol; with_statistics=false, use_uniformsolver=true, max_size = typemax(Int), max_depth = typemax(Int))
     init_node = Hole(get_domain(grammar, sym))
-    GenericSolver(grammar, init_node, with_statistics=with_statistics, use_uniformsolver=use_uniformsolver)
+    GenericSolver(grammar, init_node, with_statistics=with_statistics, use_uniformsolver=use_uniformsolver, max_size = max_size, max_depth = max_depth)
 end
 
 
@@ -41,9 +41,9 @@ end
 
 Constructs a new solver, with an initial state of the provided [`AbstractRuleNode`](@ref).
 """
-function GenericSolver(grammar::AbstractGrammar, init_node::AbstractRuleNode; with_statistics=false, use_uniformsolver=true)
+function GenericSolver(grammar::AbstractGrammar, init_node::AbstractRuleNode; with_statistics=false, use_uniformsolver=true, max_size = typemax(Int), max_depth = typemax(Int))
     stats = with_statistics ? SolverStatistics("GenericSolver") : nothing
-    solver = GenericSolver(grammar, nothing, PriorityQueue{AbstractLocalConstraint, Int}(), stats, use_uniformsolver, false, typemax(Int), typemax(Int))
+    solver = GenericSolver(grammar, nothing, PriorityQueue{AbstractLocalConstraint, Int}(), stats, use_uniformsolver, false, max_size, max_depth)
     new_state!(solver, init_node)
     return solver
 end
@@ -186,6 +186,18 @@ Get the grammar.
 """
 function get_grammar(solver::GenericSolver)::AbstractGrammar
     return solver.grammar
+end
+
+"""
+    function get_starting_symbol(solver::GenericSolver)::Symbol
+
+Get the symbol from the solver.
+"""
+function get_starting_symbol(solver::GenericSolver)::Symbol
+    root = get_tree(solver)
+    rule = isfilled(root) ?  get_rule(root) : findfirst(root.domain)
+    grammar = get_grammar(solver)
+    return grammar.types[rule]
 end
 
 


### PR DESCRIPTION
This PR adds two things:
1. Constructors where the solver has `max_depth` and `max_size`
2. A function to get the starting symbol that is used by the genetic and stochastic algorithms (Credits to @Whebon )