### PR TITLE
Add `[compat]` entry for `DataStructures`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ HerbGrammar = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 
 [compat]
+DataStructures = "^0.18.20"
 HerbCore = "^0.3.0"
 HerbGrammar = "^0.2.1"
 MLStyle = "^0.4.17"


### PR DESCRIPTION
Currently missing, which will cause JuliaHub to complain when we publish. Closes #37.