### PR TITLE
Forbiddensequence bugfix

### DIFF
--- a/src/domainrulenode.jl
+++ b/src/domainrulenode.jl
@@ -13,5 +13,15 @@ struct DomainRuleNode <: AbstractRuleNode
     children::Vector{AbstractRuleNode}
 end
 
+function DomainRuleNode(grammar::AbstractGrammar, rules::Vector{Int}, children::Vector{<:AbstractRuleNode})
+    domain = falses(length(grammar.rules))
+    for r ∈ rules
+        domain[r] = true
+    end
+    return DomainRuleNode(domain, children)
+end
+
+DomainRuleNode(grammar::AbstractGrammar, rules::Vector{Int}) = DomainRuleNode(grammar, rules, Vector{AbstractRuleNode}())
+
 #DomainRuleNode(get_domain(grammar, sym), [])
 DomainRuleNode(domain::BitVector) = DomainRuleNode(domain, [])

--- a/src/localconstraints/local_forbidden_sequence.jl
+++ b/src/localconstraints/local_forbidden_sequence.jl
@@ -51,9 +51,11 @@ function propagate!(solver::Solver, c::LocalForbiddenSequence)
                         rules = [r for r ∈ findall(node.domain) if r ∉ c.ignore_if]
                         if !isempty(rules)
                             push!(forbidden_assignments, (path_idx, rules))
-                            i -= 1
+                            break
                         end
-                        break
+                        deactivate!(solver, c)
+                        track!(solver, "LocalForbiddenSequence deactivate by ignore_if")
+                        return
                     end
                 end
             end

--- a/src/localconstraints/local_forbidden_sequence.jl
+++ b/src/localconstraints/local_forbidden_sequence.jl
@@ -100,15 +100,17 @@ function propagate!(solver::Solver, c::LocalForbiddenSequence)
             elseif (rule == forbidden_rule)
                 i -= 1
             end
-        elseif isnothing(forbidden_assignment)
+        else
             for r ∈ c.ignore_if
                 if node.domain[r]
                     #softfail (ignore if)
                     return
                 end
             end
-            forbidden_assignment = (path_idx, forbidden_rule)
-            i -= 1
+            if isnothing(forbidden_assignment)
+                forbidden_assignment = (path_idx, forbidden_rule)
+                i -= 1
+            end
         end
         if i == 0
             break

--- a/src/solver/uniform_solver/uniform_solver.jl
+++ b/src/solver/uniform_solver/uniform_solver.jl
@@ -50,11 +50,11 @@ get_name(::UniformSolver) = "UniformSolver"
 Notify all grammar constraints about the new `node` and its (grand)children
 """
 function notify_new_nodes(solver::UniformSolver, node::AbstractRuleNode, path::Vector{Int})
+    solver.path_to_node[path] = node
+    solver.node_to_path[node] = path
     for (i, childnode) ∈ enumerate(get_children(node))
         notify_new_nodes(solver, childnode, push!(copy(path), i))
     end
-    solver.path_to_node[path] = node
-    solver.node_to_path[node] = path
     for c ∈ get_grammar(solver).constraints
         on_new_node(solver, c, path)
     end

--- a/test/test_contains_subtree.jl
+++ b/test/test_contains_subtree.jl
@@ -280,5 +280,18 @@
                 @test domain_leaf_target[rule] == tree.children[1].domain[rule]
             end
         end
+
+        @testset "HardFail" begin
+            grammar = @csgrammar begin
+                S = 1
+                S = 2
+                S = 3
+                S = 4
+            end
+            addconstraint!(grammar, ContainsSubtree(DomainRuleNode(grammar, [1, 2])))
+
+            @test !isfeasible(UniformSolver(grammar, RuleNode(3)))
+            @test !isfeasible(UniformSolver(grammar, UniformHole(BitVector((0, 0, 1, 1)), [])))
+        end
     end
 end

--- a/test/test_makeequal.jl
+++ b/test/test_makeequal.jl
@@ -128,4 +128,63 @@ using HerbCore, HerbGrammar
         @test HerbConstraints.make_equal!(solver, node, varnode) isa HerbConstraints.MakeEqualSuccess
         @test node == RuleNode(4, [RuleNode(1), RuleNode(1)])
     end
+
+    @testset "MakeEqualSuccess, 1 RuleNode and a DomainRuleNode" begin
+        node = RuleNode(4, [
+            RuleNode(1), 
+            RuleNode(2)
+        ])
+        domainrulenode = DomainRuleNode(BitVector([0, 0, 1, 1]), [
+            RuleNode(1), 
+            RuleNode(2)
+        ])
+        solver, node, _ = create_dummy_solver(node, RuleNode(1))
+        
+        @test HerbConstraints.make_equal!(solver, node, domainrulenode) isa HerbConstraints.MakeEqualSuccess
+        @test node == RuleNode(4, [RuleNode(1), RuleNode(2)])
+    end
+
+    @testset "MakeEqualHardFail, 1 RuleNode and a DomainRuleNode" begin
+        node = RuleNode(4, [
+            RuleNode(1), 
+            RuleNode(2)
+        ])
+        domainrulenode = DomainRuleNode(BitVector([0, 1, 0, 0]), [
+            RuleNode(1), 
+            RuleNode(1)
+        ])
+        solver, node, _ = create_dummy_solver(node, RuleNode(1))
+        
+        @test HerbConstraints.make_equal!(solver, node, domainrulenode) isa HerbConstraints.MakeEqualHardFail
+        @test node != domainrulenode
+    end
+
+    @testset "MakeEqualHardFail, 1 AbstractHole and a DomainRuleNode" begin
+        hole = UniformHole(BitVector([1, 0, 0, 0]), [])
+        domainrulenode = DomainRuleNode(BitVector([0, 1, 0, 0]), [
+            RuleNode(1), 
+            RuleNode(1)
+        ])
+
+        solver, hole, _ = create_dummy_solver(hole, RuleNode(1))
+
+        @test HerbConstraints.make_equal!(solver, hole, domainrulenode) isa HerbConstraints.MakeEqualHardFail
+        @test hole != domainrulenode
+    end
+
+    @testset "MakeEqualSoftFail, DomainRuleNode's with VarNodes" begin
+        node = RuleNode(4, [
+            UniformHole(BitVector([1, 1, 0, 0]), []),
+            UniformHole(BitVector([1, 1, 0, 0]), [])
+        ])
+        vardomainrulenode = DomainRuleNode(BitVector([0, 0, 0, 1]), [
+            VarNode(:a), 
+            VarNode(:a)
+        ])
+
+        solver, node, _ = create_dummy_solver(node, RuleNode(1))
+
+        @test HerbConstraints.make_equal!(solver, node, vardomainrulenode) isa HerbConstraints.MakeEqualSoftFail
+        @test node != vardomainrulenode
+    end
 end


### PR DESCRIPTION
Fixes a bug in the propagator of the ForbiddenSequence constraints, spotted by the AIDM group.

The bug occurred when propagating `ForbiddenSequence([4, 1], [5]))` with 2 holes: Hole{4, 5} and Hole{1, 2}.
The propagator would incorrectly remove `1` from the second hole.