### PR TITLE
Resolve ambiguity in `in(::StateStack, ::Any)` method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbConstraints"
 uuid = "1fa96474-3206-4513-b4fa-23913f296dfc"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/solver/uniform_solver/state_stack.jl
+++ b/src/solver/uniform_solver/state_stack.jl
@@ -64,6 +64,6 @@ end
 
 Checks whether the `value` is in the `stack`.
 """
-function Base.in(stack::StateStack, value)::Bool
+function Base.in(stack::StateStack{T}, value::T)::Bool where T
     return value ∈ stack.vec[1:size(stack)]
 end

--- a/test/test_state_stack.jl
+++ b/test/test_state_stack.jl
@@ -9,6 +9,28 @@
         @test size(stack) == 0
     end
 
+    @testset "membership" begin
+        sm = HerbConstraints.StateManager()
+        stack = HerbConstraints.StateStack{Int}(sm)
+        push!(stack, 10)
+        push!(stack, 20)
+        push!(stack, 30)
+        @test in(stack, 10)
+        @test in(stack, 20)
+        @test in(stack, 30)
+        @test !in(stack, 40)
+
+        sm = HerbConstraints.StateManager()
+        stack = HerbConstraints.StateStack{String}(sm)
+        push!(stack, "A")
+        push!(stack, "B")
+        push!(stack, "C")
+        @test in(stack, "A")
+        @test in(stack, "B")
+        @test in(stack, "C")
+        @test !in(stack, "D")
+    end
+
     @testset "from vector" begin
         sm = HerbConstraints.StateManager()
         stack = HerbConstraints.StateStack{Int}(sm, [10, 20, 30])


### PR DESCRIPTION
Resolves an error raised by `Aqua.jl` complaining about method ambiguities.