### PR TITLE
Update to `HerbGrammar` v0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbConstraints"
 uuid = "1fa96474-3206-4513-b4fa-23913f296dfc"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -12,7 +12,7 @@ MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 [compat]
 DataStructures = "0.17,0.18"
 HerbCore = "^0.3.0"
-HerbGrammar = "^0.4.0"
+HerbGrammar = "0.5"
 MLStyle = "^0.4.17"
 julia = "^1.8"
 

--- a/src/solver/generic_solver/treemanipulations.jl
+++ b/src/solver/generic_solver/treemanipulations.jl
@@ -230,9 +230,15 @@ function simplify_hole!(solver::GenericSolver, path::Vector{Int})
         end
     elseif hole isa Hole
         if domain_size == 1
-            new_node = RuleNode(findfirst(hole.domain), grammar)
+            child_types = grammar.childtypes[findfirst(hole.domain)]
+            domains = [get_domain(grammar, type) for type ∈ child_types]
+            new_children = [Hole(d) for d ∈ domains]
+            new_node = RuleNode(findfirst(hole.domain), new_children)
         elseif is_subdomain(hole.domain, grammar.bychildtypes[findfirst(hole.domain)])
-            new_node = UniformHole(hole.domain, grammar)
+            child_types = grammar.childtypes[findfirst(hole.domain)]
+            domains = [get_domain(grammar, type) for type ∈ child_types]
+            new_children = [Hole(d) for d ∈ domains]
+            new_node = UniformHole(hole.domain, new_children)
         end
     else
         @assert !isnothing(hole) "No node exists at path $path in the current state"


### PR DESCRIPTION
Remove usage of grammar-based `UniformHole` and `RuleNode` constructors. These were removed from `HerbGrammar` in version v0.5. See: https://github.com/Herb-AI/HerbGrammar.jl/pull/96