### PR TITLE
Fix propagate on filled holes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbConstraints"
 uuid = "1fa96474-3206-4513-b4fa-23913f296dfc"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/solver/generic_solver/treemanipulations.jl
+++ b/src/solver/generic_solver/treemanipulations.jl
@@ -247,6 +247,9 @@ function simplify_hole!(solver::GenericSolver, path::Vector{Int})
 
     #the hole will be simplified and replaced with a `new_node`
     if !isnothing(new_node)
+        # Ideally, we should try to simplify holes with domain size of 1 here
+        # before substituting. This would remove some duplicated logic when calling
+        # pattern_match and lessthanorequal
         substitute!(solver, path, new_node, is_domain_increasing=false)
         for i ∈ 1:length(new_node.children)
             # try to simplify the new children

--- a/test/test_pattern_match.jl
+++ b/test/test_pattern_match.jl
@@ -219,6 +219,13 @@ using HerbGrammar
         @test pattern_match(rn2, mn) isa HerbConstraints.PatternMatchSoftFail
     end
 
+    @testset "PatternMatchSoftFail, 1 hole with a domain of 1, matching rulenode" begin
+        rn = Hole([0, 0, 0, 1])
+        mn = RuleNode(4, [VarNode(:a), VarNode(:a)])
+        @test pattern_match(rn, mn) isa HerbConstraints.PatternMatchSoftFail
+        @test pattern_match(mn, rn) isa HerbConstraints.PatternMatchSoftFail
+    end
+
     @testset "PatternMatchSoftFail, 2 holes with valid domains" begin
         rn = RuleNode(4, [Hole(BitVector((1, 1, 1, 1, 1, 1))), Hole(BitVector((1, 1, 1, 1, 1, 1)))])
         mn = RuleNode(4, [RuleNode(1), RuleNode(1)])


### PR DESCRIPTION
Certain patterns in grammar, like the following, cause propagation to fail.

```julia
grammar = @csgrammar begin
    Species = "A" #1
    Species = "B" #2

    SpeciesList = Species #3
    SpeciesList = SpeciesList + SpeciesList #4
    Reaction = SpeciesList --> SpeciesList #5

    ReactionList = Reaction #6
    ReactionList = ReactionList + ReactionList #7
end
```

The propagation code, updated in this PR, assumed that anything that was `isfilled(node)==true` had children, and this is sometimes not true when a hole is created for a rule like \# 5. If there is a rule like \# 6 with \# 5 as a child, that hole `isfilled` because its domain size is 1, but it has no children because it is still a hole.

I'm not sure if this is some deeper problem that we want to revisit at some point, but for now, this fix works.

Thanks to @RichardWijers for pointing this out and putting together the example:

<details><summary>Full code example</summary>

```julia
using HerbCore, HerbGrammar, HerbConstraints, HerbSearch

grammar = @csgrammar begin
    Species = "A" 
    Species = "B" 

    SpeciesList = Species
    SpeciesList = SpeciesList + SpeciesList
    Reaction = SpeciesList --> SpeciesList

    ReactionList = Reaction
    ReactionList = ReactionList + ReactionList
end

# Test without constraints
function test_unconstrained(print=false)
    println("\e[1mRunning test without constraints\e[0m")
    
    clearconstraints!(grammar)    
    iter_1 = BFSIterator(grammar, :ReactionList, max_depth=6)
    count = 0
    for program ∈ iter_1
        if print println(rulenode2expr(program, grammar)) end
        count += 1
    end
    
    println("\e[1mNumber of programs: ", count, "\e[0m")
end

# Test with constraints
function test_constrained(print=false)
    println("\e[1mRunning test with constraints\e[0m")

    clearconstraints!(grammar)
    addconstraint!(grammar, Ordered(RuleNode(4, [VarNode(:a), VarNode(:b)]), [:a, :b])) # Make species list ordered
    addconstraint!(grammar, Forbidden(RuleNode(5, [VarNode(:a), VarNode(:a)]))) # Forbid same input/output
    
    addconstraint!(grammar, Ordered(RuleNode(7, [VarNode(:a), VarNode(:b)]), [:a, :b])) # Make reaction list ordered
    addconstraint!(grammar, Forbidden(RuleNode(7, [VarNode(:a), VarNode(:a)]))) # (mostly) Forbid same reactions

    if print 
        println(grammar)
        println(grammar.constraints)
        println("\n")
    end

    iter_2 = BFSIterator(grammar, :ReactionList, max_depth=6)
    count = 0
    for program ∈ iter_2
        if print println(rulenode2expr(program, grammar)) end
        count += 1
    end
    
    println("\e[1mNumber of programs: ", count, "\e[0m")
end


println("\n\e[1m --------------------------------------------------- \e[0m\n")

# Run tests
test_unconstrained()
println("\n")
test_constrained(true)
```

<p>



</p>
</details> 