### PR TITLE
Add missing `StateSparseSet` signature to `is_subdomain`

### DIFF
--- a/src/solver/domainutils.jl
+++ b/src/solver/domainutils.jl
@@ -1,5 +1,6 @@
 """
      is_subdomain(subdomain::BitVector, domain::BitVector)
+     is_subdomain(subdomain::StateSparseSet, domain::BitVector)
 
 Checks if `subdomain` is a subdomain of `domain`.
 Example: [0, 0, 1, 0] is a subdomain of [0, 1, 1, 1]


### PR DESCRIPTION
`is_subdomain(subdomain::StateSparseSet, domain::BitVector)` was missing from the docs, so it wasn't clear that `is_subdomain` could be used with a `StateHole`.