### PR TITLE
Added dynamic typing of `StateInt`, `StateSparseSet`s; `Int` -> `<:Integer`

### DIFF
--- a/src/csg_annotated/csg_annotated.jl
+++ b/src/csg_annotated/csg_annotated.jl
@@ -37,14 +37,14 @@ g₁ = @csgrammar_annotated begin
 end
 ```
 """
-macro csgrammar_annotated(expression)
+macro csgrammar_annotated(expression::Expr)
     # collect and remove labels
     labels = _get_labels!(expression)
 
     # parse rules, get constraints from annotations
     rules = Any[]
     types = Symbol[]
-    bytype = Dict{Symbol,Vector{Int}}()
+    bytype = Dict{Symbol,Vector{Integer}}()
     constraints = Vector{AbstractConstraint}()
 
     rule_index = 1
@@ -84,7 +84,7 @@ macro csgrammar_annotated(expression)
         for new_rule ∈ new_rules
             push!(rules, new_rule)
             push!(types, lhs)
-            bytype[lhs] = push!(get(bytype, lhs, Int[]), rule_index)
+            bytype[lhs] = push!(get(bytype, lhs, Integer[]), rule_index)
             
             rule_index += 1
         end
@@ -145,10 +145,10 @@ end
 Converts an annotation to a constraint.
 commutative: creates an Ordered constraint
 transitive: creates an (incorrect) Forbidden constraint
-forbidden_path(path::Vector{Union{Symbol, Int}}): creates a ForbiddenPath constraint with the original rule included
+forbidden_path(path::Vector{Union{Symbol, Integer}}): creates a ForbiddenPath constraint with the original rule included
 ... || ...: creates a OneOf constraint (also works with ... || ... || ... et cetera, though not very performant)
 """
-function annotation2constraint(annotation::Any, rule_index::Int, labels::Vector{String})::AbstractConstraint
+function annotation2constraint(annotation::Any, rule_index::Integer, labels::Vector{String})::AbstractConstraint
     if annotation isa Expr
         # function-like annotations
         if annotation.head == :call
@@ -193,4 +193,4 @@ end
 
 
 # helper function for label lookup
-_get_rule_index(labels::Vector{String}, label::String)::Int = findfirst(isequal(label), labels)
+_get_rule_index(labels::Vector{String}, label::String)::Integer = findfirst(isequal(label), labels)

--- a/src/domainrulenode.jl
+++ b/src/domainrulenode.jl
@@ -13,7 +13,7 @@ struct DomainRuleNode <: AbstractRuleNode
     children::Vector{AbstractRuleNode}
 end
 
-function DomainRuleNode(grammar::AbstractGrammar, rules::Vector{Int}, children::Vector{<:AbstractRuleNode})
+function DomainRuleNode(grammar::AbstractGrammar, rules::Vector{<:Integer}, children::Vector{<:AbstractRuleNode})
     domain = falses(length(grammar.rules))
     for r ∈ rules
         domain[r] = true
@@ -21,7 +21,7 @@ function DomainRuleNode(grammar::AbstractGrammar, rules::Vector{Int}, children::
     return DomainRuleNode(domain, children)
 end
 
-DomainRuleNode(grammar::AbstractGrammar, rules::Vector{Int}) = DomainRuleNode(grammar, rules, Vector{AbstractRuleNode}())
+DomainRuleNode(grammar::AbstractGrammar, rules::Vector{<:Integer}) = DomainRuleNode(grammar, rules, Vector{AbstractRuleNode}())
 
 #DomainRuleNode(get_domain(grammar, sym), [])
 DomainRuleNode(domain::BitVector) = DomainRuleNode(domain, [])

--- a/src/grammarconstraints/contains.jl
+++ b/src/grammarconstraints/contains.jl
@@ -3,10 +3,10 @@ Contains <: AbstractGrammarConstraint
 This [`AbstractGrammarConstraint`] enforces that a given `rule` appears in the program tree at least once.
 """
 struct Contains <: AbstractGrammarConstraint
-    rule::Int
+    rule::Integer
 end
 
-function on_new_node(solver::Solver, c::Contains, path::Vector{Int})
+function on_new_node(solver::Solver, c::Contains, path::Vector{<:Integer})
     if length(path) == 0
         #only post a local constraint at the root
         post!(solver, LocalContains(path, c.rule))

--- a/src/grammarconstraints/contains_subtree.jl
+++ b/src/grammarconstraints/contains_subtree.jl
@@ -10,13 +10,13 @@ struct ContainsSubtree <: AbstractGrammarConstraint
     tree::AbstractRuleNode
 end
 
-function on_new_node(solver::UniformSolver, c::ContainsSubtree, path::Vector{Int})
+function on_new_node(solver::UniformSolver, c::ContainsSubtree, path::Vector{<:Integer})
     if length(path) == 0
         post!(solver, LocalContainsSubtree(path, c.tree, nothing, nothing))
     end
 end
 
-function on_new_node(::GenericSolver, ::ContainsSubtree, ::Vector{Int}) end
+function on_new_node(::GenericSolver, ::ContainsSubtree, ::Vector{<:Integer}) end
 
 """
     check_tree(c::ContainsSubtree, tree::AbstractRuleNode)::Bool

--- a/src/grammarconstraints/forbidden.jl
+++ b/src/grammarconstraints/forbidden.jl
@@ -23,7 +23,7 @@ struct Forbidden <: AbstractGrammarConstraint
     tree::AbstractRuleNode
 end
 
-function on_new_node(solver::Solver, c::Forbidden, path::Vector{Int})
+function on_new_node(solver::Solver, c::Forbidden, path::Vector{<:Integer})
     #minor optimization: prevent the first hardfail (https://github.com/orgs/Herb-AI/projects/6/views/1?pane=issue&itemId=55570518)
     if c.tree isa RuleNode
         @match get_node_at_location(solver, path) begin

--- a/src/grammarconstraints/forbidden_sequence.jl
+++ b/src/grammarconstraints/forbidden_sequence.jl
@@ -20,13 +20,13 @@ Consider the following paths from the root:
 - `[1, 99, 1, 2, 3]` is forbidden, as there is a subsequence that does not contain `99`
 """
 struct ForbiddenSequence <: AbstractGrammarConstraint
-    sequence::Vector{Int}
-    ignore_if::Vector{Int}
+    sequence::Vector{Integer}
+    ignore_if::Vector{Integer}
 end
 
-ForbiddenSequence(sequence::Vector{Int}; ignore_if=Vector{Int}()) = ForbiddenSequence(sequence, ignore_if)
+ForbiddenSequence(sequence::Vector{<:Integer}; ignore_if=Vector{Integer}()) = ForbiddenSequence(sequence, ignore_if)
 
-function on_new_node(solver::Solver, c::ForbiddenSequence, path::Vector{Int})
+function on_new_node(solver::Solver, c::ForbiddenSequence, path::Vector{<:Integer})
     #minor optimization: prevent the first hardfail (https://github.com/orgs/Herb-AI/projects/6/views/1?pane=issue&itemId=55570518)
     @match get_node_at_location(solver, path) begin
         hole::AbstractHole => if !hole.domain[c.sequence[end]] return end

--- a/src/grammarconstraints/ordered.jl
+++ b/src/grammarconstraints/ordered.jl
@@ -29,7 +29,7 @@ struct Ordered <: AbstractGrammarConstraint
     order::Vector{Symbol}
 end
 
-function on_new_node(solver::Solver, c::Ordered, path::Vector{Int})
+function on_new_node(solver::Solver, c::Ordered, path::Vector{<:Integer})
     #minor optimization: prevent the first hardfail (https://github.com/orgs/Herb-AI/projects/6/views/1?pane=issue&itemId=55570518)
     if c.tree isa RuleNode
         @match get_node_at_location(solver, path) begin

--- a/src/grammarconstraints/unique.jl
+++ b/src/grammarconstraints/unique.jl
@@ -4,11 +4,11 @@
 This [`AbstractGrammarConstraint`] enforces that a given `rule` appears in the program tree at most once.
 """
 struct Unique <: AbstractGrammarConstraint
-    rule::Int
+    rule::Integer
 end
 
 
-function on_new_node(solver::Solver, c::Unique, path::Vector{Int})
+function on_new_node(solver::Solver, c::Unique, path::Vector{<:Integer})
     if length(path) == 0
         #only post a local constraint at the root
         post!(solver, LocalUnique(path, c.rule))
@@ -17,11 +17,11 @@ end
 
 
 """
-    function _count_occurrences(rule::Int, node::AbstractRuleNode)::Int
+    function _count_occurrences(rule::Integer, node::AbstractRuleNode)::Integer
 
 Recursively counts the number of occurrences of the `rule` in the `node`.
 """
-function _count_occurrences(node::AbstractRuleNode, rule::Int)::Int
+function _count_occurrences(node::AbstractRuleNode, rule::Integer)::Integer
     @assert isfilled(node)
     count = (get_rule(node) == rule) ? 1 : 0
     for child ∈ get_children(node)

--- a/src/lessthanorequal.jl
+++ b/src/lessthanorequal.jl
@@ -83,11 +83,11 @@ function make_less_than_or_equal!(
     hole1::Union{RuleNode, AbstractHole}, 
     hole2::Union{RuleNode, AbstractHole}
 )::LessThanOrEqualResult
-    make_less_than_or_equal!(solver, hole1, hole2, Vector{Tuple{AbstractHole, Int}}())
+    make_less_than_or_equal!(solver, hole1, hole2, Vector{Tuple{AbstractHole, Integer}}())
 end
 
 """
-    function make_less_than_or_equal!(h1::Union{RuleNode, AbstractHole}, h2::Union{RuleNode, AbstractHole}, guards::Vector{Tuple{AbstractHole, Int}})::LessThanOrEqualResult
+    function make_less_than_or_equal!(h1::Union{RuleNode, AbstractHole}, h2::Union{RuleNode, AbstractHole}, guards::Vector{Tuple{AbstractHole, Integer}})::LessThanOrEqualResult
 
 Helper function that keeps track of the guards
 """
@@ -95,7 +95,7 @@ function make_less_than_or_equal!(
     solver::Solver, 
     hole1::Union{RuleNode, AbstractHole}, 
     hole2::Union{RuleNode, AbstractHole},
-    guards::Vector{Tuple{AbstractHole, Int}}
+    guards::Vector{Tuple{AbstractHole, Integer}}
 )::LessThanOrEqualResult
     @assert isfeasible(solver)
     @match (isfilled(hole1), isfilled(hole2)) begin
@@ -241,7 +241,7 @@ function make_less_than_or_equal!(
 end
 
 """
-    function make_less_than_or_equal!(solver::Solver, nodes1::Vector{AbstractRuleNode}, nodes2::Vector{AbstractRuleNode}, guards::Vector{Tuple{AbstractHole, Int}})::LessThanOrEqualResult
+    function make_less_than_or_equal!(solver::Solver, nodes1::Vector{AbstractRuleNode}, nodes2::Vector{AbstractRuleNode}, guards::Vector{Tuple{AbstractHole, Integer}})::LessThanOrEqualResult
 
 Helper function that tiebreaks on children.
 """
@@ -249,7 +249,7 @@ function make_less_than_or_equal!(
     solver::Solver,
     nodes1::Vector{AbstractRuleNode},
     nodes2::Vector{AbstractRuleNode},
-    guards::Vector{Tuple{AbstractHole, Int}}
+    guards::Vector{Tuple{AbstractHole, Integer}}
 )::LessThanOrEqualResult
     for (node1, node2) ∈ zip(nodes1, nodes2)
         result = make_less_than_or_equal!(solver, node1, node2, guards)

--- a/src/localconstraints/local_contains.jl
+++ b/src/localconstraints/local_contains.jl
@@ -5,8 +5,8 @@ LocalContains
 Enforces that a given `rule` appears at or below the given `path` at least once.
 """
 struct LocalContains <: AbstractLocalConstraint
-	path::Vector{Int}
-    rule::Int
+	path::Vector{Integer}
+    rule::Integer
 end
 
 """
@@ -51,7 +51,7 @@ function propagate!(solver::Solver, c::LocalContains)
 end
 
 """
-    _contains(node::AbstractRuleNode, rule::Int)::Bool
+    _contains(node::AbstractRuleNode, rule::Integer)::Bool
 
 Recursive helper function for the LocalContains constraint
 Returns one of the following:
@@ -59,11 +59,11 @@ Returns one of the following:
 - `false`, if the `node` does not contain the `rule`
 - `Vector{AbstractHole}`, if the `node` contains the `rule` if one the `holes` gets filled with the target rule
 """
-function _contains(node::AbstractRuleNode, rule::Int)::Union{Vector{AbstractHole}, Bool}
+function _contains(node::AbstractRuleNode, rule::Integer)::Union{Vector{AbstractHole}, Bool}
     return _contains(node, rule, Vector{AbstractHole}())
 end
 
-function _contains(node::AbstractRuleNode, rule::Int, holes::Vector{AbstractHole})::Union{Vector{AbstractHole}, Bool}
+function _contains(node::AbstractRuleNode, rule::Integer, holes::Vector{AbstractHole})::Union{Vector{AbstractHole}, Bool}
     if !isuniform(node)
         # the rule might appear underneath this non-uniform hole
         push!(holes, node)
@@ -81,7 +81,7 @@ function _contains(node::AbstractRuleNode, rule::Int, holes::Vector{AbstractHole
     return _contains(get_children(node), rule, holes)
 end
 
-function _contains(children::Vector{AbstractRuleNode}, rule::Int, holes::Vector{AbstractHole})::Union{Vector{AbstractHole}, Bool}
+function _contains(children::Vector{AbstractRuleNode}, rule::Integer, holes::Vector{AbstractHole})::Union{Vector{AbstractHole}, Bool}
     for child ∈ children
         if _contains(child, rule, holes) == true
             return true

--- a/src/localconstraints/local_contains_subtree.jl
+++ b/src/localconstraints/local_contains_subtree.jl
@@ -9,18 +9,18 @@ Enforces that a given `tree` appears at or below the given `path` at least once.
     The `indices` and `candidates` fields should not be set by the user.
 """
 mutable struct LocalContainsSubtree <: AbstractLocalConstraint
-	path::Vector{Int}
+	path::Vector{Integer}
     tree::AbstractRuleNode
     candidates::Union{Vector{AbstractRuleNode}, Nothing}
     indices::Union{StateSparseSet, Nothing}
 end
 
 """
-    LocalContainsSubtree(path::Vector{Int}, tree::AbstractRuleNode)
+    LocalContainsSubtree(path::Vector{<:Integer}, tree::AbstractRuleNode)
 
 Enforces that a given `tree` appears at or below the given `path` at least once.
 """
-function LocalContainsSubtree(path::Vector{Int}, tree::AbstractRuleNode)
+function LocalContainsSubtree(path::Vector{<:Integer}, tree::AbstractRuleNode)
     LocalContainsSubtree(path, tree, Vector{AbstractRuleNode}(), nothing)
 end
 

--- a/src/localconstraints/local_forbidden.jl
+++ b/src/localconstraints/local_forbidden.jl
@@ -7,7 +7,7 @@ provided by the path.
 Use a `Forbidden` constraint for enforcing this throughout the entire search space.
 """
 struct LocalForbidden <: AbstractLocalConstraint
-    path::Vector{Int}
+    path::Vector{Integer}
     tree::AbstractRuleNode
 end
 

--- a/src/localconstraints/local_forbidden_sequence.jl
+++ b/src/localconstraints/local_forbidden_sequence.jl
@@ -5,17 +5,17 @@ Forbids the given `sequence` of rule nodes ending at the node at the `path`.
 If any of the rules in `ignore_if` appears in the sequence, the constraint is ignored.
 """
 struct LocalForbiddenSequence <: AbstractLocalConstraint
-    path::Vector{Int}
-    sequence::Vector{Int}
-    ignore_if::Vector{Int}
+    path::Vector{Integer}
+    sequence::Vector{Integer}
+    ignore_if::Vector{Integer}
 end
 
 """
-    shouldschedule(::Solver, constraint::LocalForbiddenSequence, path::Vector{Int})::Bool
+    shouldschedule(::Solver, constraint::LocalForbiddenSequence, path::Vector{<:Integer})::Bool
 
 Return true iff the manipulation happened at or above the constraint path.
 """
-function shouldschedule(::Solver, constraint::LocalForbiddenSequence, path::Vector{Int})::Bool
+function shouldschedule(::Solver, constraint::LocalForbiddenSequence, path::Vector{<:Integer})::Bool
     return (length(constraint.path) >= length(path)) && (path== constraint.path[1:length(path)] )
 end
 
@@ -28,7 +28,7 @@ function propagate!(solver::Solver, c::LocalForbiddenSequence)
     track!(solver, "LocalForbiddenSequence propagation")
 
     # Smallest match
-    forbidden_assignments = Vector{Tuple{Int, Any}}()
+    forbidden_assignments = Vector{Tuple{Integer, Any}}()
     i = length(c.sequence)
     for (path_idx, node) ∈ Iterators.reverse(enumerate(nodes))
         forbidden_rule = c.sequence[i]
@@ -75,7 +75,7 @@ function propagate!(solver::Solver, c::LocalForbiddenSequence)
         return
     elseif length(forbidden_assignments) == 1
         path_idx, rule = forbidden_assignments[1]
-        if rule isa Int
+        if rule isa Integer
             track!(solver, "LocalForbiddenSequence deduction")
         else
             track!(solver, "LocalForbiddenSequence deduction by ignore_if")
@@ -134,11 +134,11 @@ end
 
 
 """
-    function get_nodes_on_path(root::AbstractRuleNode, path::Vector{Int})::Vector{AbstractRuleNode}
+    function get_nodes_on_path(root::AbstractRuleNode, path::Vector{<:Integer})::Vector{AbstractRuleNode}
 
 Gets a list of nodes on the `path`, starting (and including) the `root`.
 """
-function get_nodes_on_path(node::AbstractRuleNode, path::Vector{Int})::Vector{AbstractRuleNode}
+function get_nodes_on_path(node::AbstractRuleNode, path::Vector{<:Integer})::Vector{AbstractRuleNode}
     nodes = Vector{AbstractRuleNode}()
     push!(nodes, node)
     for i ∈ path

--- a/src/localconstraints/local_ordered.jl
+++ b/src/localconstraints/local_ordered.jl
@@ -4,7 +4,7 @@ specified in `order` when the pattern is applied at the location given by `path`
 Use an `Ordered` constraint for enforcing this throughout the entire search space.
 """
 mutable struct LocalOrdered <: AbstractLocalConstraint
-    path::Vector{Int}
+    path::Vector{Integer}
     tree::AbstractRuleNode
     order::Vector{Symbol}
 end

--- a/src/localconstraints/local_unique.jl
+++ b/src/localconstraints/local_unique.jl
@@ -6,12 +6,12 @@ Enforces that a given `rule` appears at or below the given `path` at most once.
 In case of the UniformSolver, cache the list of `holes`, since no new holes can appear.
 """
 struct LocalUnique <: AbstractLocalConstraint
-	path::Vector{Int}
-    rule::Int
+	path::Vector{Integer}
+    rule::Integer
     holes::Vector{AbstractHole}
 end
 
-LocalUnique(path::Vector{Int}, rule::Int) = LocalUnique(path, rule, Vector{AbstractHole}())
+LocalUnique(path::Vector{<:Integer}, rule::Integer) = LocalUnique(path, rule, Vector{AbstractHole}())
 
 """
     function propagate!(solver::Solver, c::LocalUnique)
@@ -51,7 +51,7 @@ function propagate!(solver::Solver, c::LocalUnique)
 end
 
 """
-    function _count_occurrences!(node::AbstractRuleNode, rule::Int, holes::Vector{AbstractHole})::Int
+    function _count_occurrences!(node::AbstractRuleNode, rule::Integer, holes::Vector{AbstractHole})::Integer
 
 Recursive helper function for the LocalUnique constraint.
 Returns the number of certain occurrences of the rule in the tree.
@@ -61,7 +61,7 @@ All holes that potentially can hold the target rule are stored in the `holes` ve
     Stops counting if the rule occurs more than once. 
     Counting beyond 2 is not needed for LocalUnique. 
 """
-function _count_occurrences!(node::AbstractRuleNode, rule::Int, holes::Vector{AbstractHole})::Int
+function _count_occurrences!(node::AbstractRuleNode, rule::Integer, holes::Vector{AbstractHole})::Integer
     count = 0
     if isfilled(node)
         # if the rulenode is the second occurence of the rule, hardfail
@@ -87,7 +87,7 @@ function _count_occurrences!(node::AbstractRuleNode, rule::Int, holes::Vector{Ab
 end
 
 """
-    function _count_occurrences(holes::Vector{AbstractHole}, rule::Int)
+    function _count_occurrences(holes::Vector{AbstractHole}, rule::Integer)
 
 Counts the occurences of the `rule` in the cached list of `holes`.
 
@@ -95,7 +95,7 @@ Counts the occurences of the `rule` in the cached list of `holes`.
     Stops counting if the rule occurs more than once. 
     Counting beyond 2 is not needed for LocalUnique. 
 """
-function _count_occurrences(holes::Vector{AbstractHole}, rule::Int)
+function _count_occurrences(holes::Vector{AbstractHole}, rule::Integer)
     count = 0
     for hole ∈ holes
         if isfilled(hole) && get_rule(hole) == rule

--- a/src/patternmatch.jl
+++ b/src/patternmatch.jl
@@ -20,7 +20,7 @@ The pattern can be matched when the `hole` is filled with any of the given `ind`
 """
 struct PatternMatchSuccessWhenHoleAssignedTo <: PatternMatchResult
     hole::AbstractHole
-    ind::Union{Int, Vector{Int}}
+    ind::Union{Integer, Vector{<:Integer}}
 end
 
 """

--- a/src/solver/domainutils.jl
+++ b/src/solver/domainutils.jl
@@ -110,15 +110,15 @@ end
 
 Returns all the values that are in both `domain1` and `domain2`
 """
-function get_intersection(domain1::BitVector, domain2::BitVector)::Vector{Int}
+function get_intersection(domain1::BitVector, domain2::BitVector)::Vector{<:Integer}
     return findall(domain1 .& domain2)
 end
-function get_intersection(sss::Union{BitVector, StateSparseSet}, domain2::Union{BitVector, StateSparseSet})::Vector{Int}
+function get_intersection(sss::Union{BitVector, StateSparseSet}, domain2::Union{BitVector, StateSparseSet})::Vector{<:Integer}
     if !(sss isa StateSparseSet) 
         sss, domain2 = domain2, sss
         @assert sss isa StateSparseSet
     end
-    intersection = Vector{Int}()
+    intersection = Vector{Integer}()
     for v ∈ sss
         if domain2[v]
             push!(intersection, v)

--- a/src/solver/generic_solver/treemanipulations.jl
+++ b/src/solver/generic_solver/treemanipulations.jl
@@ -1,10 +1,10 @@
 """
-    remove!(solver::GenericSolver, path::Vector{Int}, rule_index::Int)
+    remove!(solver::GenericSolver, path::Vector{<:Integer}, rule_index::Integer)
 
 Remove `rule_index` from the domain of the hole located at the `path`.
 It is assumed the path points to a hole, otherwise an exception will be thrown.
 """
-function remove!(solver::GenericSolver, path::Vector{Int}, rule_index::Int)
+function remove!(solver::GenericSolver, path::Vector{<:Integer}, rule_index::Integer)
     hole = get_hole_at_location(solver, path)
     if !hole.domain[rule_index]
         # The rule is not present in the domain, ignore the tree manipulation
@@ -17,12 +17,12 @@ function remove!(solver::GenericSolver, path::Vector{Int}, rule_index::Int)
 end
 
 """
-    remove!(solver::GenericSolver, path::Vector{Int}, rules::Vector{Int})
+    remove!(solver::GenericSolver, path::Vector{<:Integer}, rules::Vector{<:Integer})
 
 Remove all `rules` from the domain of the hole located at the `path`.
 It is assumed the path points to a hole, otherwise an exception will be thrown.
 """
-function remove!(solver::GenericSolver, path::Vector{Int}, rules::Vector{Int})
+function remove!(solver::GenericSolver, path::Vector{<:Integer}, rules::Vector{<:Integer})
     hole = get_hole_at_location(solver, path)
     domain_updated = false
     for rule_index ∈ rules
@@ -39,13 +39,13 @@ function remove!(solver::GenericSolver, path::Vector{Int}, rules::Vector{Int})
 end
 
 """
-    remove_all_but!(solver::GenericSolver, path::Vector{Int}, new_domain::BitVector)
+    remove_all_but!(solver::GenericSolver, path::Vector{<:Integer}, new_domain::BitVector)
 
 Reduce the domain of the hole located at the `path`, to the `new_domain`.
 It is assumed the path points to a hole, otherwise an exception will be thrown.
 It is assumed new_domain ⊆ domain. For example: [1, 0, 1, 0] ⊆ [1, 0, 1, 1]
 """
-function remove_all_but!(solver::GenericSolver, path::Vector{Int}, new_domain::BitVector)
+function remove_all_but!(solver::GenericSolver, path::Vector{<:Integer}, new_domain::BitVector)
     hole = get_hole_at_location(solver, path)
     if hole.domain == new_domain @warn "'remove_all_but' was called with trivial arguments" return end
     @assert is_subdomain(new_domain, hole.domain) "($new_domain) ⊈ ($(hole.domain)) The remaining rules are required to be a subdomain of the hole to remove from"
@@ -56,14 +56,14 @@ function remove_all_but!(solver::GenericSolver, path::Vector{Int}, new_domain::B
 end
 
 """
-    remove_above!(solver::GenericSolver, path::Vector{Int}, rule_index::Int)
+    remove_above!(solver::GenericSolver, path::Vector{<:Integer}, rule_index::Integer)
 
 Reduce the domain of the hole located at the `path` by removing all rules indices above `rule_index`
 Example:
 `rule_index` = 2. 
 `hole` with domain [1, 1, 0, 1] gets reduced to [1, 0, 0, 0] and gets simplified to a `RuleNode`
 """
-function remove_above!(solver::GenericSolver, path::Vector{Int}, rule_index::Int)
+function remove_above!(solver::GenericSolver, path::Vector{<:Integer}, rule_index::Integer)
     hole = get_hole_at_location(solver, path)
     highest_ind = findlast(hole.domain)
     if highest_ind <= rule_index
@@ -80,14 +80,14 @@ function remove_above!(solver::GenericSolver, path::Vector{Int}, rule_index::Int
 end
 
 """
-    remove_below!(solver::GenericSolver, path::Vector{Int}, rule_index::Int)
+    remove_below!(solver::GenericSolver, path::Vector{<:Integer}, rule_index::Integer)
 
 Reduce the domain of the hole located at the `path` by removing all rules indices below `rule_index`
 Example:
 `rule_index` = 2. 
 `hole` with domain [1, 1, 0, 1] gets reduced to [0, 1, 0, 1]
 """
-function remove_below!(solver::GenericSolver, path::Vector{Int}, rule_index::Int)
+function remove_below!(solver::GenericSolver, path::Vector{<:Integer}, rule_index::Integer)
     hole = get_hole_at_location(solver, path)
     lowest_ind = findfirst(hole.domain)
     if lowest_ind >= rule_index
@@ -104,7 +104,7 @@ function remove_below!(solver::GenericSolver, path::Vector{Int}, rule_index::Int
 end
 
 """
-    remove_all_but!(solver::GenericSolver, path::Vector{Int}, rule_index::Int)
+    remove_all_but!(solver::GenericSolver, path::Vector{<:Integer}, rule_index::Integer)
 
 Fill in the hole located at the `path` with rule `rule_index`.
 It is assumed the path points to a hole, otherwise an exception will be thrown.
@@ -113,7 +113,7 @@ It is assumed rule_index ∈ hole.domain.
 !!! warning: If the `hole` is known to be in the current tree, the hole can be passed directly.
     The caller has to make sure that the hole instance is actually present at the provided `path`.
 """
-function remove_all_but!(solver::GenericSolver, path::Vector{Int}, rule_index::Int; hole::Union{Hole, Nothing}=nothing)
+function remove_all_but!(solver::GenericSolver, path::Vector{<:Integer}, rule_index::Integer; hole::Union{Hole, Nothing}=nothing)
     if isnothing(hole)
         hole = get_hole_at_location(solver, path)
     end
@@ -140,7 +140,7 @@ end
 
 
 """
-    substitute!(solver::GenericSolver, path::Vector{Int}, new_node::AbstractRuleNode; is_domain_increasing::Union{Nothing, Bool}=nothing)
+    substitute!(solver::GenericSolver, path::Vector{<:Integer}, new_node::AbstractRuleNode; is_domain_increasing::Union{Nothing, Bool}=nothing)
 
 Substitute the node at the `path`, with a `new_node`.
 * `is_domain_increasing`: indicates if all grammar constraints should be repropagated from the ground up.
@@ -148,7 +148,7 @@ Domain increasing substitutions are substitutions that cannot be achieved by rep
 Example of an domain increasing event: `hole[{3, 4, 5}] -> hole[{1, 2}]`.
 Example of an domain decreasing event: `hole[{3, 4, 5}] -> rulenode(4, [hole[{1, 2}], rulenode(1)])`.
 """
-function substitute!(solver::GenericSolver, path::Vector{Int}, new_node::AbstractRuleNode; is_domain_increasing::Union{Nothing, Bool}=nothing)
+function substitute!(solver::GenericSolver, path::Vector{<:Integer}, new_node::AbstractRuleNode; is_domain_increasing::Union{Nothing, Bool}=nothing)
     if isempty(path)
         #replace the root
         old_node = solver.state.tree
@@ -194,11 +194,11 @@ end
 
 
 """
-    function remove_node!(solver::GenericSolver, path::Vector{Int})
+    function remove_node!(solver::GenericSolver, path::Vector{<:Integer})
 
 Remove the node at the given `path` by substituting it with a hole of the same symbol.
 """
-function remove_node!(solver::GenericSolver, path::Vector{Int})
+function remove_node!(solver::GenericSolver, path::Vector{<:Integer})
     track!(solver, "remove_node!")
     node = get_node_at_location(solver, path)
     @assert !(node isa Hole)
@@ -210,12 +210,12 @@ end
 
 
 """
-    simplify_hole!(solver::GenericSolver, path::Vector{Int})
+    simplify_hole!(solver::GenericSolver, path::Vector{<:Integer})
 
 Takes a [Hole](@ref) and tries to simplify it to a [UniformHole](@ref) or [RuleNode](@ref).
 If the domain of the hole is empty, the state will be marked as infeasible
 """
-function simplify_hole!(solver::GenericSolver, path::Vector{Int})
+function simplify_hole!(solver::GenericSolver, path::Vector{<:Integer})
     if !isfeasible(solver) return end
     hole = get_hole_at_location(solver, path)
     grammar = get_grammar(solver)

--- a/src/solver/solver.jl
+++ b/src/solver/solver.jl
@@ -5,7 +5,7 @@ Abstract constraint solver.
 Each solver should have at least the following fields:
 - `statistics::SolverStatistics`
 - `fix_point_running::Bool`
-- `schedule::PriorityQueue{AbstractLocalConstraint, Int}`
+- `schedule::PriorityQueue{AbstractLocalConstraint, Integer}`
 
 Each solver should implement at least:
 - `post!`
@@ -58,14 +58,14 @@ end
 
 
 """
-    shouldschedule(solver::Solver, constraint::AbstractLocalConstraint, path::Vector{Int})::Bool
+    shouldschedule(solver::Solver, constraint::AbstractLocalConstraint, path::Vector{<:Integer})::Bool
 
 Function that is called when a tree manipulation occured at the `path`.
 Returns true if the `constraint` should be scheduled for propagation.
 
 Default behavior: return true iff the manipulation happened at or below the constraint path.
 """
-function shouldschedule(::Solver, constraint::AbstractLocalConstraint, path::Vector{Int})::Bool
+function shouldschedule(::Solver, constraint::AbstractLocalConstraint, path::Vector{<:Integer})::Bool
     return (length(path) >= length(constraint.path)) && (path[1:length(constraint.path)] == constraint.path)
 end
 

--- a/src/solver/solverstatistics.jl
+++ b/src/solver/solverstatistics.jl
@@ -2,10 +2,10 @@
 Temporary struct to `track!` the number of several function calls centered around the [`Solver`](@ref)
 """
 struct SolverStatistics
-    dict::Dict{String, Int}
+    dict::Dict{String, Integer}
 end
 
-SolverStatistics() = SolverStatistics(Dict{String, Int}())
+SolverStatistics() = SolverStatistics(Dict{String, Integer}())
 
 function track!(solver::Solver, key::String)
     if !isnothing(solver.statistics)

--- a/src/solver/uniform_solver/state_hole.jl
+++ b/src/solver/uniform_solver/state_hole.jl
@@ -34,11 +34,11 @@ HerbCore.isuniform(::StateHole) = true
 
 
 """
-	get_rule(hole::StateHole)::Int
+	get_rule(hole::StateHole)::Integer
 
 Assuming the hole has domain size 1, get the rule it is currently assigned to.
 """
-function HerbCore.get_rule(hole::StateHole)::Int
+function HerbCore.get_rule(hole::StateHole)::Integer
 	@assert isfilled(hole) "$(hole) has not been filled yet, unable to get the rule"
 	return findfirst(hole.domain)
 end

--- a/src/solver/uniform_solver/state_manager.jl
+++ b/src/solver/uniform_solver/state_manager.jl
@@ -19,8 +19,13 @@ Supports the following functions:
 """
 mutable struct StateInt
     sm::AbstractStateManager
-    val::Int
-    last_state_id::Int
+    val::Integer
+    last_state_id::Integer
+
+    function StateInt(sm::AbstractStateManager, val::Integer, last_state_id::Integer)
+        IntType = HerbCore.smallest_Int_type(val)
+        new(sm, IntType(val), last_state_id)
+    end
 end
 
 function StateInt(sm, val)
@@ -29,7 +34,7 @@ end
 
 
 """
-Get the value of the stateful integer
+Get the value of the stateful integer/
 """
 function get_value(int::StateInt)
     return int.val
@@ -39,10 +44,10 @@ end
 """
 Set the value of the integer to the given `val`
 """
-function set_value!(int::StateInt, val::Int)
+function set_value!(int::StateInt, val::Integer)
     if int.val != val
         backup!(int)
-        int.val = val
+        int.val = HerbCore.smallest_Int_type(val)(val)
     end
 end
 
@@ -70,7 +75,7 @@ Backup entry for the given [`StateInt`](@ref)
 """
 struct StateIntBackup
     state_int::StateInt
-    original_val::Int
+    original_val::Integer
 end
 
 
@@ -118,7 +123,7 @@ Manages all changes made to StateInts using StateIntBackups
 mutable struct StateManager <: AbstractStateManager
     prior_backups::Vector{Vector{StateIntBackup}}       # backups of previous save points
     current_backups::Vector{StateIntBackup}             # backups of changes made since the last save point
-    current_state_id::Int
+    current_state_id::Integer
 end
 
 function StateManager()

--- a/src/solver/uniform_solver/state_sparse_set.jl
+++ b/src/solver/uniform_solver/state_sparse_set.jl
@@ -1,18 +1,20 @@
 struct StateSparseSet
-    values::Vector{Int}
-    indices::Vector{Int}
+    values::Vector{Integer}
+    indices::Vector{Integer}
     size::StateInt
     min::StateInt
     max::StateInt
-    n::Int
+    n::Integer
 end
 
 """
 Create a new `StateSparseSet` with values [1, 2, ..., n]
 """
-function StateSparseSet(sm::StateManager, n::Int)
-    values = collect(1:n)
-    indices = collect(1:n)
+function StateSparseSet(sm::StateManager, n::Integer)
+    IntType = HerbCore.smallest_Int_type(n)
+    values = Vector{IntType}(collect(1:n))
+    indices = Vector{IntType}(collect(1:n))   
+
     size = StateInt(sm, n)
     min = StateInt(sm, 1)
     max = StateInt(sm, n)
@@ -28,8 +30,11 @@ set = StateSparseSet(sm, BitVector((1, 1, 0, 0, 1, 0, 0))) #{1, 2, 5}
 """
 function StateSparseSet(sm::StateManager, domain::BitVector)
     n = length(domain)
-    values = collect(1:n)
-    indices = collect(1:n)
+
+    IntType = HerbCore.smallest_Int_type(n)
+
+    values = Vector{IntType}(collect(1:n))
+    indices = Vector{IntType}(collect(1:n))
     size = StateInt(sm, n)
     min = StateInt(sm, 1)
     max = StateInt(sm, n)
@@ -101,7 +106,7 @@ Checks if value `val` is in StateSparseSet `s`.
 !!! warning:
     This allows a `StateSparseSet` to be used as if it were a `BitVector` representation of a set
 """
-function Base.getindex(set::StateSparseSet, val::Int)
+function Base.getindex(set::StateSparseSet, val::Integer)
     return val ∈ set
 end
 
@@ -125,7 +130,7 @@ end
 """
 Checks if value `val` is in StateSparseSet `s`.
 """
-function Base.in(val::Int, set::StateSparseSet)
+function Base.in(val::Integer, set::StateSparseSet)
     if val < 1 || val > set.n
         return false
     end
@@ -133,7 +138,7 @@ function Base.in(val::Int, set::StateSparseSet)
 end
 
 
-Base.eltype(::StateSparseSet) = Int
+Base.eltype(::StateSparseSet) = Integer
 
 
 function Base.iterate(set::StateSparseSet)
@@ -143,7 +148,7 @@ function Base.iterate(set::StateSparseSet)
 end
 
 
-function Base.iterate(set::StateSparseSet, index::Int)
+function Base.iterate(set::StateSparseSet, index::Integer)
     index += 1
     if index > get_value(set.size) return nothing end
     return set.values[index], index
@@ -151,11 +156,11 @@ end
 
 
 """
-    remove!(set::StateSparseSet, val::Int)
+    remove!(set::StateSparseSet, val::Integer)
 
 Removes value `val` from StateSparseSet `set`. Returns true if `val` was in `set`.
 """
-function remove!(set::StateSparseSet, val::Int)::Bool
+function remove!(set::StateSparseSet, val::Integer)::Bool
     if val ∉ set
         return false;
     end
@@ -167,11 +172,11 @@ end
 
 
 """
-    remove_all_but!(set::StateSparseSet, val::Int)::Bool
+    remove_all_but!(set::StateSparseSet, val::Integer)::Bool
 
 Removes all values from StateSparseSet `set`, except `val`
 """
-function remove_all_but!(set::StateSparseSet, val::Int)::Bool
+function remove_all_but!(set::StateSparseSet, val::Integer)::Bool
     @assert val ∈ set
     if get_value(set.size) <= 1
         return false
@@ -192,7 +197,7 @@ end
 """
 Remove all the values less than `val` from the `set`
 """
-function remove_below!(set::StateSparseSet, val::Int)::Bool
+function remove_below!(set::StateSparseSet, val::Integer)::Bool
     if get_value(set.min) >= val
         return false
     elseif get_value(set.max) < val
@@ -208,7 +213,7 @@ end
 """
 Remove all the values greater than `val` from the `set`
 """
-function remove_above!(set::StateSparseSet, val::Int)::Bool
+function remove_above!(set::StateSparseSet, val::Integer)::Bool
     if get_value(set.max) <= val
         return false
     elseif get_value(set.min) > val
@@ -224,7 +229,7 @@ end
 """
 Exchanges the positions in the internal representation of the StateSparseSet.
 """
-function _exchange_positions!(set::StateSparseSet, val1::Int, val2::Int)
+function _exchange_positions!(set::StateSparseSet, val1::Integer, val2::Integer)
     @assert (val1 >= 1) && (val2 >= 1) && (val1 <= set.n) && (val2 <= set.n)
     v1 = val1
     v2 = val2
@@ -240,7 +245,7 @@ end
 This function should be called whenever the minimum or maximum value from the set might have been removed.
 The minimum and maximum value of the set will be updated to the actual bounds of the set.
 """
-function _update_bounds_val_removed!(set::StateSparseSet, val::Int)
+function _update_bounds_val_removed!(set::StateSparseSet, val::Integer)
     _update_max_val_removed!(set, val)
     _update_min_val_removed!(set, val)
 end
@@ -249,7 +254,7 @@ end
 This function should be called whenever the maximum value from the set might have been removed.
 The maximum value of the set will be updated to the actual maximum of the set.
 """
-function _update_max_val_removed!(set::StateSparseSet, val::Int)
+function _update_max_val_removed!(set::StateSparseSet, val::Integer)
     max = get_value(set.max)
     if !isempty(set) && max == val
         for v ∈ max-1:-1:1
@@ -265,7 +270,7 @@ end
 This function should be called whenever the minimum value from the set might have been removed.
 The minimum value of the set will be updated to the actual minimum of the set.
 """
-function _update_min_val_removed!(set::StateSparseSet, val::Int)
+function _update_min_val_removed!(set::StateSparseSet, val::Integer)
     min = get_value(set.min)
     if !isempty(set) && min == val
         for v ∈ min+1:set.n

--- a/src/solver/uniform_solver/state_stack.jl
+++ b/src/solver/uniform_solver/state_stack.jl
@@ -44,7 +44,7 @@ end
 
 Get the current size of the `stack`.
 """
-function Base.size(stack::StateStack)::Int
+function Base.size(stack::StateStack)::Integer
     return get_value(stack.size)
 end
 

--- a/src/solver/uniform_solver/uniform_solver.jl
+++ b/src/solver/uniform_solver/uniform_solver.jl
@@ -5,12 +5,12 @@ mutable struct UniformSolver <: Solver
     grammar::AbstractGrammar
     sm::StateManager
     tree::Union{RuleNode, StateHole}
-    path_to_node::Dict{Vector{Int}, AbstractRuleNode}
-    node_to_path::Dict{AbstractRuleNode, Vector{Int}}
+    path_to_node::Dict{Vector{Integer}, AbstractRuleNode}
+    node_to_path::Dict{AbstractRuleNode, Vector{Integer}}
     isactive::Dict{AbstractLocalConstraint, StateInt}
     canceledconstraints::Set{AbstractLocalConstraint}
     isfeasible::Bool
-    schedule::PriorityQueue{AbstractLocalConstraint, Int}
+    schedule::PriorityQueue{AbstractLocalConstraint, Integer}
     fix_point_running::Bool
     statistics::Union{SolverStatistics, Nothing}
 end
@@ -23,11 +23,11 @@ function UniformSolver(grammar::AbstractGrammar, fixed_shaped_tree::AbstractRule
     @assert !contains_nonuniform_hole(fixed_shaped_tree) "$(fixed_shaped_tree) contains non-uniform holes"
     sm = StateManager()
     tree = StateHole(sm, fixed_shaped_tree)
-    path_to_node = Dict{Vector{Int}, AbstractRuleNode}()
-    node_to_path = Dict{AbstractRuleNode, Vector{Int}}()
+    path_to_node = Dict{Vector{Integer}, AbstractRuleNode}()
+    node_to_path = Dict{AbstractRuleNode, Vector{Integer}}()
     isactive = Dict{AbstractLocalConstraint, StateInt}()
     canceledconstraints = Set{AbstractLocalConstraint}()
-    schedule = PriorityQueue{AbstractLocalConstraint, Int}()
+    schedule = PriorityQueue{AbstractLocalConstraint, Integer}()
     fix_point_running = false
     statistics = @match with_statistics begin
         ::SolverStatistics => with_statistics
@@ -35,7 +35,7 @@ function UniformSolver(grammar::AbstractGrammar, fixed_shaped_tree::AbstractRule
         ::Nothing => nothing
     end
     solver = UniformSolver(grammar, sm, tree, path_to_node, node_to_path, isactive, canceledconstraints, true, schedule, fix_point_running, statistics)
-    notify_new_nodes(solver, tree, Vector{Int}())
+    notify_new_nodes(solver, tree, Vector{Integer}())
     fix_point!(solver)
     return solver
 end
@@ -45,11 +45,11 @@ get_name(::UniformSolver) = "UniformSolver"
 
 
 """
-    notify_new_nodes(solver::UniformSolver, node::AbstractRuleNode, path::Vector{Int})
+    notify_new_nodes(solver::UniformSolver, node::AbstractRuleNode, path::Vector{<:Integer})
 
 Notify all grammar constraints about the new `node` and its (grand)children
 """
-function notify_new_nodes(solver::UniformSolver, node::AbstractRuleNode, path::Vector{Int})
+function notify_new_nodes(solver::UniformSolver, node::AbstractRuleNode, path::Vector{<:Integer})
     solver.path_to_node[path] = node
     solver.node_to_path[node] = path
     for (i, childnode) ∈ enumerate(get_children(node))
@@ -66,27 +66,27 @@ end
 
 Get the path at which the `node` is located.
 """
-function HerbCore.get_path(solver::UniformSolver, node::AbstractRuleNode)::Vector{Int}
+function HerbCore.get_path(solver::UniformSolver, node::AbstractRuleNode)::Vector{Integer}
     return solver.node_to_path[node]
 end
 
 
 """
-    get_node_at_location(solver::UniformSolver, path::Vector{Int})
+    get_node_at_location(solver::UniformSolver, path::Vector{<:Integer})
 
 Get the node that is located at the provided `path`.
 """
-function HerbCore.get_node_at_location(solver::UniformSolver, path::Vector{Int})
+function HerbCore.get_node_at_location(solver::UniformSolver, path::Vector{<:Integer})
     return solver.path_to_node[path]
 end
 
 
 """
-    get_hole_at_location(solver::UniformSolver, path::Vector{Int})
+    get_hole_at_location(solver::UniformSolver, path::Vector{<:Integer})
 
 Get the hole that is located at the provided `path`.
 """
-function get_hole_at_location(solver::UniformSolver, path::Vector{Int})
+function get_hole_at_location(solver::UniformSolver, path::Vector{<:Integer})
     hole = solver.path_to_node[path]
     @assert hole isa StateHole
     return hole
@@ -177,11 +177,11 @@ end
 
 
 """
-    notify_tree_manipulation(solver::UniformSolver, event_path::Vector{Int})
+    notify_tree_manipulation(solver::UniformSolver, event_path::Vector{<:Integer})
 
 Notify subscribed constraints that a tree manipulation has occured at the `event_path` by scheduling them for propagation
 """
-function notify_tree_manipulation(solver::UniformSolver, event_path::Vector{Int})
+function notify_tree_manipulation(solver::UniformSolver, event_path::Vector{<:Integer})
     if !isfeasible(solver) return end
     for (constraint, isactive) ∈ solver.isactive
         if get_value(isactive) == 1

--- a/src/solver/uniform_solver/uniform_treemanipulations.jl
+++ b/src/solver/uniform_solver/uniform_treemanipulations.jl
@@ -1,10 +1,10 @@
 """
-    remove!(solver::Solver, path::Vector{Int}, rule_index::Int)
+    remove!(solver::Solver, path::Vector{<:Integer}, rule_index::Integer)
 
 Remove `rule_index` from the domain of the hole located at the `path`.
 It is assumed the path points to a hole, otherwise an exception will be thrown.
 """
-function remove!(solver::UniformSolver, path::Vector{Int}, rule_index::Int)
+function remove!(solver::UniformSolver, path::Vector{<:Integer}, rule_index::Integer)
     #remove the rule_index from the state sparse set of the hole
     hole = get_hole_at_location(solver, path)
     if remove!(hole.domain, rule_index)
@@ -17,12 +17,12 @@ function remove!(solver::UniformSolver, path::Vector{Int}, rule_index::Int)
 end
 
 """
-    remove!(solver::UniformSolver, path::Vector{Int}, rules::Vector{Int})
+    remove!(solver::UniformSolver, path::Vector{<:Integer}, rules::Vector{<:Integer})
 
 Remove all `rules` from the domain of the hole located at the `path`.
 It is assumed the path points to a hole, otherwise an exception will be thrown.
 """
-function remove!(solver::UniformSolver, path::Vector{Int}, rules::Vector{Int})
+function remove!(solver::UniformSolver, path::Vector{<:Integer}, rules::Vector{<:Integer})
     #remove the rule_index from the state sparse set of the hole
     hole = get_hole_at_location(solver, path)
     domain_updated = false
@@ -41,14 +41,14 @@ function remove!(solver::UniformSolver, path::Vector{Int}, rules::Vector{Int})
 end
 
 """
-    remove_above!(solver::UniformSolver, path::Vector{Int}, rule_index::Int)
+    remove_above!(solver::UniformSolver, path::Vector{<:Integer}, rule_index::Integer)
 
 Reduce the domain of the hole located at the `path` by removing all rules indices above `rule_index`
 Example:
 `rule_index` = 2. 
 `hole` with domain {1, 2, 4} gets reduced to {1}
 """
-function remove_above!(solver::UniformSolver, path::Vector{Int}, rule_index::Int)
+function remove_above!(solver::UniformSolver, path::Vector{<:Integer}, rule_index::Integer)
     hole = get_hole_at_location(solver, path)
     if remove_above!(hole.domain, rule_index)
         if isempty(hole.domain)
@@ -60,14 +60,14 @@ function remove_above!(solver::UniformSolver, path::Vector{Int}, rule_index::Int
 end
 
 """
-    remove_below!(solver::UniformSolver, path::Vector{Int}, rule_index::Int)
+    remove_below!(solver::UniformSolver, path::Vector{<:Integer}, rule_index::Integer)
 
 Reduce the domain of the hole located at the `path` by removing all rules indices below `rule_index`
 Example:
 `rule_index` = 2. 
 `hole` with domain {1, 2, 4} gets reduced to {2, 4}
 """
-function remove_below!(solver::UniformSolver, path::Vector{Int}, rule_index::Int)
+function remove_below!(solver::UniformSolver, path::Vector{<:Integer}, rule_index::Integer)
     hole = get_hole_at_location(solver, path)
     if remove_below!(hole.domain, rule_index)
         if isempty(hole.domain)
@@ -79,11 +79,11 @@ function remove_below!(solver::UniformSolver, path::Vector{Int}, rule_index::Int
 end
 
 """
-    remove_all_but!(solver::UniformSolver, path::Vector{Int}, rule_index::Int)
+    remove_all_but!(solver::UniformSolver, path::Vector{<:Integer}, rule_index::Integer)
 
 Fill in the hole located at the `path` with rule `rule_index`.
 """
-function remove_all_but!(solver::UniformSolver, path::Vector{Int}, rule_index::Int)
+function remove_all_but!(solver::UniformSolver, path::Vector{<:Integer}, rule_index::Integer)
     hole = get_hole_at_location(solver, path)
     if remove_all_but!(hole.domain, rule_index)
         if isempty(hole.domain)


### PR DESCRIPTION
- `StateInt` and `StateSparseSet` are now parametric and dynamically decide for the smallest type using `HerbCore.smallest_Int_type`.
- The default type for everything integer is not the concrete type `Int` (which defaults to `Int64` on 64-bit machines) but now the abstract type `Integer` (for which `UInt8 <: Integer` and `Int <: Integer` holds)

Requires https://github.com/Herb-AI/HerbCore.jl/pull/41

**Why this is still a draft:**
We have to decide what types we want to allow here—the more types we iterate over in `smallest_Int_type,` the slower the enumeration potentially. I will test this as soon as possible. 