### PR TITLE
Perf/uniform solver

### DIFF
--- a/src/solver/uniform_solver/state_hole.jl
+++ b/src/solver/uniform_solver/state_hole.jl
@@ -16,17 +16,23 @@ Converts a [`UniformHole`](@ref) to a [`StateHole`](@ref)
 """
 function StateHole(sm::StateManager, hole::UniformHole)
 	sss_domain = StateSparseSet(sm, hole.domain)
-	children = [StateHole(sm, child) for child ∈ hole.children]
+	children = [StateHole(sm, child, length(hole.domain)) for child ∈ hole.children]
 	return StateHole(sss_domain, children)
 end
+
+StateHole(sm::StateManager, hole::UniformHole, _) = StateHole(sm, hole)
 
 
 """
 Converts a [`RuleNode`](@ref) to a [`StateHole`](@ref)
 """
-function StateHole(sm::StateManager, rulenode::RuleNode)
-	children = [StateHole(sm, child) for child ∈ rulenode.children]
-	return RuleNode(rulenode.ind, children)
+function StateHole(sm::StateManager, rulenode::RuleNode, domain_length)
+	domain = BitVector(zeros(domain_length))
+	domain[rulenode.ind] = 1
+	domain_set = StateSparseSet(sm, domain)
+
+	children = [StateHole(sm, child, domain_length) for child ∈ rulenode.children]
+	return StateHole(domain_set, children)
 end
 
 

--- a/test/test_state_fixed_shaped_hole.jl
+++ b/test/test_state_fixed_shaped_hole.jl
@@ -32,12 +32,14 @@ using HerbCore
         @test get_rule(node) == 4
 
         node = root.children[1].children[2]
-        @test node isa RuleNode
-        @test node.ind == 4
+        @test node isa StateHole
+        @test node.domain[4] == true
+        @test isfilled(node)
 
         node = root.children[2]
-        @test node isa RuleNode
-        @test node.ind == 5
+        @test node isa StateHole
+        @test node.domain[5] == true
+        @test isfilled(node)
 
         node = root.children[2].children[1]
         @test size(node.domain) == 2
@@ -75,16 +77,16 @@ using HerbCore
             RuleNode(2),
             RuleNode(1)
         ])
-        statehole = StateHole(sm, node)
+        statehole = StateHole(sm, node, 3)
         @test node == statehole
         @test statehole == node
-        @test statehole == StateHole(sm, node)
+        @test statehole == StateHole(sm, node, 3)
 
         node2 = RuleNode(3, [
             RuleNode(1),
             RuleNode(1)
         ])
-        statehole2 = StateHole(sm, node2)
+        statehole2 = StateHole(sm, node2, 3)
         @test node != statehole2
         @test statehole2 != node
         @test statehole != statehole2
@@ -96,7 +98,7 @@ using HerbCore
 
         io = IOBuffer()
         Base.show(io, sh)
-        @test String(take!(io)) == "statehole[{1, 2}]{1,2}"
+        @test String(take!(io)) == "statehole[{1, 2}]{statehole[{1}],statehole[{2}]}"
 
         sh = StateHole(sm, UniformHole(BitVector((1, 1, 0)), [])) 
         


### PR DESCRIPTION
Draft PR to fix type instabilities in `HerbConstraints`. 
The root cause is the `UniformIterator` not knowing what subtype of `AbstractRuleNode` it faces. However, these are only `StateHole` or `RuleNode`.

We now transform every `RuleNode` to a `StateHole` first, and then only handle this case. 

**TODO**:
- `StateHole(..., ::Rulenode)` does not know the domain size, which hence has to be passed. Let us find a cleaner solution to this.