### PR TITLE
Add softfail if one hole is 'filled' but is a hole

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbConstraints"
 uuid = "1fa96474-3206-4513-b4fa-23913f296dfc"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/lessthanorequal.jl
+++ b/src/lessthanorequal.jl
@@ -148,6 +148,9 @@ function make_less_than_or_equal!(
                     return LessThanOrEqualSuccessLessThan()
                 end
                 # tiebreak on the children
+                if hole1 isa Hole && !isempty(get_children(hole2))
+                    return LessThanOrEqualSoftFail(hole1)
+                end
                 return make_less_than_or_equal!(solver, hole1.children, hole2.children, guards)
             else
                 return LessThanOrEqualSoftFail(hole2)
@@ -181,6 +184,9 @@ function make_less_than_or_equal!(
                     return LessThanOrEqualSuccessLessThan()
                 end
                 # tiebreak on the children
+                if hole2 isa Hole && !isempty(get_children(hole1))
+                    return LessThanOrEqualSoftFail(hole2)
+                end
                 return make_less_than_or_equal!(solver, hole1.children, hole2.children, guards)
             else
                 return LessThanOrEqualSoftFail(hole1)

--- a/test/test_lessthanorequal.jl
+++ b/test/test_lessthanorequal.jl
@@ -149,7 +149,7 @@ using HerbCore, HerbGrammar
         rightpath = get_path(tree, right)
         new_state!(solver, tree)
         left = get_node_at_location(solver, leftpath) #leftnode might have been simplified by `new_state!`
-        left = get_node_at_location(solver, rightpath) #rightnode might have been simplified by `new_state!`
+        right = get_node_at_location(solver, rightpath) #rightnode might have been simplified by `new_state!`
 
         @test HerbConstraints.make_less_than_or_equal!(solver, left, right) isa HerbConstraints.LessThanOrEqualSoftFail
         @test HerbConstraints.make_less_than_or_equal!(solver, right, left) isa HerbConstraints.LessThanOrEqualSoftFail


### PR DESCRIPTION
Addresses the same issue as #69 but which arises when adding the ordered constraint with >= 3 arguments.

```julia
grammar = @csgrammar begin
    Number = 1 | 2
    Number = Number + Number + Number
end

addconstraint!(grammar, Ordered(RuleNode(3, [VarNode(:a), VarNode(:b), VarNode(:c)]), [:a, :b, :c]))

iterator = BFSIterator(grammar, :Number, max_depth=3)

length(iterator)
```

Running this code gives a `LoadError: type Hole has no field children`

The previous MR addresses the problem that arose because we assumed that anything that was `isfilled(node) == true` had children. However, this fix is only present in the (true, true) case of `isfilled(hole1), isfilled(hole2)`. Now, the check is also present in the cases where one of the two holes is filled.