### PR TITLE
Add support for multiple indices in remove_all_but!

### DIFF
--- a/src/solver/generic_solver/treemanipulations.jl
+++ b/src/solver/generic_solver/treemanipulations.jl
@@ -56,6 +56,26 @@ function remove_all_but!(solver::GenericSolver, path::Vector{Int}, new_domain::B
 end
 
 """
+    remove_all_but!(solver::GenericSolver, path::Vector{Int}, rules_to_keep::Vector{Int})
+
+Remove all rules from the domain of the hole located at the `path` except for the rules in `rules_to_keep`.
+"""
+function remove_all_but!(solver::GenericSolver, path::Vector{Int}, rules_indices::Vector{Int})
+    hole = get_hole_at_location(solver, path)
+
+    bit_to_keep = BitVector(falses(length(hole.domain)))
+    bit_to_keep[rules_indices] .= true
+
+    updated_domain = hole.domain .& bit_to_keep
+    if hole.domain != updated_domain
+        hole.domain = updated_domain
+        simplify_hole!(solver, path)
+        notify_tree_manipulation(solver, path)
+        fix_point!(solver)
+    end
+end
+
+"""
     remove_above!(solver::GenericSolver, path::Vector{Int}, rule_index::Int)
 
 Reduce the domain of the hole located at the `path` by removing all rules indices above `rule_index`

--- a/src/solver/uniform_solver/state_sparse_set.jl
+++ b/src/solver/uniform_solver/state_sparse_set.jl
@@ -194,16 +194,16 @@ end
 Removes all values from StateSparseSet `set`, except those in `vals`
 """
 function remove_all_but!(set::StateSparseSet, vals::Vector{Int})::Bool
-    to_remove = filter(v -> v ∉ vals, collect(set))
-    if isempty(to_remove)
-        return false
+    @assert issubset(vals, set) "$vals is not a subset of $set"
+    removed = false
+
+    for v in set
+        if v ∉ vals
+            removed = removed || remove!(set, v)
+        end
     end
-    
-    for v in to_remove
-        remove!(set, v)
-    end
-    
-    return true
+
+    return removed
 end
 
 """

--- a/src/solver/uniform_solver/state_sparse_set.jl
+++ b/src/solver/uniform_solver/state_sparse_set.jl
@@ -188,6 +188,23 @@ function remove_all_but!(set::StateSparseSet, val::Int)::Bool
     return true
 end
 
+"""
+    remove_all_but!(set::StateSparseSet, vals::Vector{Int})::Bool
+
+Removes all values from StateSparseSet `set`, except those in `vals`
+"""
+function remove_all_but!(set::StateSparseSet, vals::Vector{Int})::Bool
+    to_remove = filter(v -> v ∉ vals, collect(set))
+    if isempty(to_remove)
+        return false
+    end
+    
+    for v in to_remove
+        remove!(set, v)
+    end
+    
+    return true
+end
 
 """
 Remove all the values less than `val` from the `set`

--- a/src/solver/uniform_solver/uniform_treemanipulations.jl
+++ b/src/solver/uniform_solver/uniform_treemanipulations.jl
@@ -83,7 +83,7 @@ end
 
 Fill in the hole located at the `path` with rule `rule_index`.
 """
-function remove_all_but!(solver::UniformSolver, path::Vector{Int}, rule_index::Int)
+function remove_all_but!(solver::UniformSolver, path::Vector{Int}, rule_index::Union{Int, Vector{Int}})
     hole = get_hole_at_location(solver, path)
     if remove_all_but!(hole.domain, rule_index)
         if isempty(hole.domain)

--- a/test/test_state_sparse_set.jl
+++ b/test/test_state_sparse_set.jl
@@ -179,15 +179,10 @@
         @test result == true
 
         set = HerbConstraints.StateSparseSet(HerbConstraints.StateManager(), BitVector((1, 0, 1)))
-        result = remove_all_but!(set, [2])
-        @test length(set) == 0
-        @test result == true
-        
+        @test_throws Exception remove_all_but!(set, [2])
+
         set = HerbConstraints.StateSparseSet(HerbConstraints.StateManager(), BitVector((1, 0, 1)))
-        result = remove_all_but!(set, [2, 3])
-        @test length(set) == 1
-        @test 3 ∈ set
-        @test result == true
+        @test_throws Exception remove_all_but!(set, [2, 3])
 
         set = HerbConstraints.StateSparseSet(HerbConstraints.StateManager(), BitVector((1, 0, 1)))
         result = remove_all_but!(set, [1, 3])

--- a/test/test_state_sparse_set.jl
+++ b/test/test_state_sparse_set.jl
@@ -171,6 +171,29 @@
         remove_all_but!(set, 2)
         @test length(set) == 1
         @test 2 ∈ set
+
+        set = HerbConstraints.StateSparseSet(HerbConstraints.StateManager(), BitVector((1, 0, 1)))
+        result = remove_all_but!(set, [1])
+        @test length(set) == 1
+        @test 1 ∈ set
+        @test result == true
+
+        set = HerbConstraints.StateSparseSet(HerbConstraints.StateManager(), BitVector((1, 0, 1)))
+        result = remove_all_but!(set, [2])
+        @test length(set) == 0
+        @test result == true
+        
+        set = HerbConstraints.StateSparseSet(HerbConstraints.StateManager(), BitVector((1, 0, 1)))
+        result = remove_all_but!(set, [2, 3])
+        @test length(set) == 1
+        @test 3 ∈ set
+        @test result == true
+
+        set = HerbConstraints.StateSparseSet(HerbConstraints.StateManager(), BitVector((1, 0, 1)))
+        result = remove_all_but!(set, [1, 3])
+        @test length(set) == 2
+        @test 1 ∈ set && 3 ∈ set
+        @test result == false
     end
 
     @testset "are_disjoint" begin

--- a/test/test_treemanipulations.jl
+++ b/test/test_treemanipulations.jl
@@ -75,5 +75,28 @@ using HerbCore, HerbGrammar
         @test tree.children[2] == RuleNode(2)
     end
 
+
+    @testset "remove_all_but! (vector)" begin
+        solver = create_dummy_solver()
+        new_state!(solver, @rulenode Hole[1, 1, 1, 1])
+        remove_all_but!(solver, Int[], [2, 3])
+        node = get_tree(solver)
+        @test node.domain == BitVector((0, 1, 1, 0))
+    
+        new_state!(solver, @rulenode Hole[1, 1, 1, 1])
+        remove_all_but!(solver, Int[], [1, 2])
+        node = get_tree(solver)
+        @test node.domain == BitVector((1, 1, 0, 0))
+    
+        new_state!(solver, @rulenode Hole[1, 1, 0, 1])
+        remove_all_but!(solver, Int[], [3, 4])
+        node = get_tree(solver)
+        @test node.ind == 4
+    
+        new_state!(solver, @rulenode Hole[0, 1, 0, 1])
+        remove_all_but!(solver, Int[], [2, 4])
+        node = get_tree(solver)
+        @test node.domain == BitVector((0, 1, 0, 1))
+    end
 end
 

--- a/test/test_uniform_treemanipulations.jl
+++ b/test/test_uniform_treemanipulations.jl
@@ -1,0 +1,27 @@
+using HerbCore, HerbGrammar
+
+@testset verbose=false "Tree Manipulations (UniformSolver)" begin
+
+    function create_dummy_solver(tree)
+        grammar = @csgrammar begin
+            Number = x | 1
+            Number = Number + Number
+            Number = Number - Number
+        end
+        return UniformSolver(grammar, tree)
+    end
+
+    @testset "remove_all_but! (vector)" begin
+        tree = @rulenode UniformHole[1, 1, 0, 0]
+        solver = create_dummy_solver(tree)
+        remove_all_but!(solver, Int[], 1)
+        node = get_tree(solver)
+        @test collect(node.domain) == [1]
+
+        solver = create_dummy_solver(tree)
+        remove_all_but!(solver, Int[], [1, 2])
+        node = get_tree(solver)
+        @test collect(node.domain) == [1, 2]
+    end
+end
+


### PR DESCRIPTION
Instead of only being able to keep a single index, add support for a vector
`remove_all_but!(solver, path, indices::Vector{Int})`

So when you for example pass indices `[1, 3]`, would do the following to bitvector domains:

```
[1, 1, 1, 1] -> [1, 0, 1, 0]
[0, 1, 0, 0] -> [0, 0, 0, 0]
[1, 0, 0, 1] -> [1, 0, 0, 0]
```