### PR TITLE
Revert part of `isfilled` fix from #78

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbConstraints"
 uuid = "1fa96474-3206-4513-b4fa-23913f296dfc"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/lessthanorequal.jl
+++ b/src/lessthanorequal.jl
@@ -98,9 +98,7 @@ function make_less_than_or_equal!(
     guards::Vector{Tuple{AbstractHole, Int}}
 )::LessThanOrEqualResult
     @assert isfeasible(solver)
-    # must test both `isfilled` and `isa Hole` because a `Hole` may be `isfilled` (domain size == 1)
-    # but it still does not have children (`Hole`s cannot have children, only `<:AbstractUniformHole`s can)
-    @match (isfilled(hole1) && !(hole1 isa Hole), isfilled(hole2) && !(hole2 isa Hole)) begin
+    @match (isfilled(hole1), isfilled(hole2)) begin
         (true, true) => begin
             #(RuleNode | Hole [domain size == 1], RuleNode | Hole [domain size == 1])
             if get_rule(hole1) < get_rule(hole2)


### PR DESCRIPTION
In the next episode of the `lessthanorequal` series...

It turns out it was not necessary to check whether hole was a hole in addition to the `isfilled` check. It was sufficient to switch the `holeX.children` field accesses (which don't exist) to `get_children(holeX)` (which return an empty list).

Without this fix, the following will error:

```julia
grammar = @cfgrammar begin
    Number = 1
    Number = 2
    Number = Number + Number + Number
end

addconstraint!(grammar, Ordered(RuleNode(3, [VarNode(:a), VarNode(:b), VarNode(:c)]), [:a, :b, :c]))
iterator = BFSIterator(grammar, :Number, max_depth=3)
length(iterator)
```

```julia
MethodError: Cannot `convert` an object of type Nothing to an object of type Vector{Int64}
  The function `convert` exists, but no method is defined for this combination of argument types.
  
  Closest candidates are:
    Array{T, N}(::Nothing, Any...) where {T, N}
     @ Base baseext.jl:42
    convert(::Type{T}, ::AbstractArray) where T<:Array
     @ Base array.jl:618
    convert(::Type{T}, ::T) where T
     @ Base Base.jl:126
    ...
  
  Stacktrace:
   [1] get_path(solver::GenericSolver, node::Hole)
     @ HerbConstraints ~/.../HerbConstraints.jl/src/solver/generic_solver/generic_solver.jl:269
   [2] make_less_than_or_equal!(solver::GenericSolver, hole1::Hole, hole2::Hole, guards::Vector{Tuple{AbstractHole, Int64}})
     @ HerbConstraints ~/.../HerbConstraints.jl/src/lessthanorequal.jl:130
   [3] make_less_than_or_equal!(solver::GenericSolver, hole1::Hole, hole2::Hole)
     @ HerbConstraints ~/.../HerbConstraints.jl/src/lessthanorequal.jl:86
   [4] macro expansion
     @ /.../share/julia/stdlib/v1.11/Test/src/Test.jl:676 [inlined]
   [5] macro expansion
     @ ~/.../HerbConstraints.jl/test/test_lessthanorequal.jl:179 [inlined]
   [6] macro expansion
     @ /.../share/julia/stdlib/v1.11/Test/src/Test.jl:1704 [inlined]
   [7] macro expansion
     @ ~/.../HerbConstraints.jl/test/test_lessthanorequal.jl:159 [inlined]
   [8] macro expansion
     @ /.../share/julia/stdlib/v1.11/Test/src/Test.jl:1704 [inlined]
   [9] top-level scope
     @ ~/.../HerbConstraints.jl/test/test_lessthanorequal.jl:158
```

@Sebastien1999 and I tried to get this to a minimal test for `HerbConstraints` (without using an iterator from `HerbSearch` ), but couldn't seem to replicate the exact behavior.