### PR TITLE
Update rule indices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbConstraints"
 uuid = "1fa96474-3206-4513-b4fa-23913f296dfc"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Jaap de Jong <jaapdejong15@gmail.com>"]
 version = "0.4.0"
 
 [deps]
-AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
 HerbGrammar = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 [compat]
 DataStructures = "0.17,0.18"
 HerbCore = "^0.3.0"
-HerbGrammar = "0.5"
+HerbGrammar = "0.6"
 MLStyle = "^0.4.17"
 TimerOutputs = "0.5.28"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Jaap de Jong <jaapdejong15@gmail.com>"]
 version = "0.4.0"
 
 [deps]
+AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
 HerbGrammar = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"

--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -15,6 +15,30 @@ Grammar constraints should implement `on_new_node` to post a [`AbstractLocalCons
 """
 abstract type AbstractGrammarConstraint <: AbstractConstraint end
 
+# Interface for update_rule_indices!
+"""
+    function update_rule_indices!(node::AbstractGrammarConstraint,n_rules::Integer)
+
+Used to update constraints when the grammar changes, e.g., by adding rules or merging grammars.
+"""
+function update_rule_indices!(c::AbstractGrammarConstraint,
+    n_rules::Integer
+)
+    error("update_rule_indices! not implemented for constraint type $(typeof(c))")
+end
+
+"""
+    function update_rule_indices!(node::AbstractGrammarConstraint,n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer})
+
+Used to update constraints when the grammar changes, e.g., by adding rules or merging grammars.
+"""
+function update_rule_indices!(c::AbstractGrammarConstraint,
+    n_rules::Integer,
+    mapping::AbstractDict{<:Integer,<:Integer}
+)
+    error("update_rule_indices! not implemented for constraint type $(typeof(c))")
+end
+
 """
     abstract type AbstractLocalConstraint <: AbstractConstraint
 
@@ -40,6 +64,7 @@ Constraints with fast propagators and/or strong inference should be propagated f
 function get_priority(::AbstractLocalConstraint)
     return 0
 end
+
 
 include("csg_annotated/csg_annotated.jl")
 
@@ -80,13 +105,11 @@ include("grammarconstraints/utils.jl")
 
 export
     AbstractGrammarConstraint,
-    AbstractLocalConstraint,
-
-    DomainRuleNode,
+    AbstractLocalConstraint, DomainRuleNode,
     VarNode,
     pattern_match,
     check_tree,
-    
+
     #grammar constraints
     Forbidden,
     Ordered,
@@ -148,7 +171,6 @@ export
     #state fixed shaped hole
     StateHole,
     freeze_state,
-
     update_rule_indices!
 
 end # module HerbConstraints

--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -5,6 +5,8 @@ using HerbGrammar
 using DataStructures
 using MLStyle
 using TimerOutputs
+using AutoHashEquals
+
 
 """
     abstract type AbstractGrammarConstraint <: AbstractConstraint

--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -28,8 +28,26 @@ Used to update constraints when the grammar changes, e.g., by adding rules or me
 # Notes
 Individual implementations may not use all provided arguments.
 """
-function update_rule_indices!(c::AbstractGrammarConstraint,
+function HerbCore.update_rule_indices!(c::AbstractGrammarConstraint,
     n_rules::Integer
+)
+    error("update_rule_indices! not implemented for constraint type $(typeof(c))")
+end
+
+"""
+    function update_rule_indices!(node::AbstractGrammarConstraint,grammar::AbstractGrammar)
+
+Used to update constraints when the grammar changes, e.g., by adding rules or merging grammars.
+
+# Arguments
+- `c`: The `AbstractGrammarConstraint` to be updated
+- `grammar`: The grammar that changed
+
+# Notes
+Individual implementations may not use all provided arguments.
+"""
+function HerbCore.update_rule_indices!(c::AbstractGrammarConstraint,
+    grammar::AbstractGrammar
 )
     error("update_rule_indices! not implemented for constraint type $(typeof(c))")
 end
@@ -48,10 +66,30 @@ Used to update constraints when the grammar changes, e.g., by adding rules or me
 # Notes
 Individual implementations may not use all provided arguments.
 """
-function update_rule_indices!(c::AbstractGrammarConstraint,
+function HerbCore.update_rule_indices!(c::AbstractGrammarConstraint,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
     constraints::Vector{<:AbstractConstraint}
+)
+    error("update_rule_indices! not implemented for constraint type $(typeof(c))")
+end
+
+"""
+    function update_rule_indices!(node::AbstractGrammarConstraint,grammar::AbstractGrammar, mapping::AbstractDict{<:Integer,<:Integer})
+
+Used to update constraints when the grammar changes, e.g., by adding rules or merging grammars. 
+
+# Arguments
+- `c`: The `AbstractGrammarConstraint` to be updated
+- `grammar`: The grammar that changed
+- `mapping`: Dictionary mapping old rule indices to new rule indices
+
+# Notes
+Individual implementations may not use all provided arguments.
+"""
+function HerbCore.update_rule_indices!(c::AbstractGrammarConstraint,
+    grammar::AbstractGrammar,
+    mapping::AbstractDict{<:Integer,<:Integer}
 )
     error("update_rule_indices! not implemented for constraint type $(typeof(c))")
 end

--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -20,6 +20,13 @@ abstract type AbstractGrammarConstraint <: AbstractConstraint end
     function update_rule_indices!(node::AbstractGrammarConstraint,n_rules::Integer)
 
 Used to update constraints when the grammar changes, e.g., by adding rules or merging grammars.
+
+# Arguments
+- `c`: The `AbstractGrammarConstraint` to be updated
+- `n_rules`: The new number of rules in the grammar
+
+# Notes
+Individual implementations may not use all provided arguments.
 """
 function update_rule_indices!(c::AbstractGrammarConstraint,
     n_rules::Integer
@@ -28,9 +35,18 @@ function update_rule_indices!(c::AbstractGrammarConstraint,
 end
 
 """
-    function update_rule_indices!(node::AbstractGrammarConstraint,n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer})
+    function update_rule_indices!(node::AbstractGrammarConstraint,n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer}, constraints::Vector{AbstractConstraint})
 
-Used to update constraints when the grammar changes, e.g., by adding rules or merging grammars.
+Used to update constraints when the grammar changes, e.g., by adding rules or merging grammars. 
+
+# Arguments
+- `c`: The `AbstractGrammarConstraint` to be updated
+- `n_rules`: The new number of rules in the grammar
+- `mapping`: Dictionary mapping old rule indices to new rule indices
+- `constraints`: List of grammar constraints
+
+# Notes
+Individual implementations may not use all provided arguments.
 """
 function update_rule_indices!(c::AbstractGrammarConstraint,
     n_rules::Integer,
@@ -171,6 +187,7 @@ export
     #state fixed shaped hole
     StateHole,
     freeze_state,
-    update_rule_indices!
+    update_rule_indices!,
+    removeconstraint!
 
 end # module HerbConstraints

--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -16,85 +16,6 @@ Grammar constraints should implement `on_new_node` to post a [`AbstractLocalCons
 """
 abstract type AbstractGrammarConstraint <: AbstractConstraint end
 
-# Interface for update_rule_indices!
-"""
-    function update_rule_indices!(node::AbstractGrammarConstraint,n_rules::Integer)
-
-Used to update constraints when the grammar changes, e.g., by adding rules or merging grammars.
-
-# Arguments
-- `c`: The `AbstractGrammarConstraint` to be updated
-- `n_rules`: The new number of rules in the grammar
-
-# Notes
-Individual implementations may not use all provided arguments.
-"""
-function HerbCore.update_rule_indices!(c::AbstractGrammarConstraint,
-    n_rules::Integer
-)
-    error("update_rule_indices! not implemented for constraint type $(typeof(c))")
-end
-
-"""
-    function update_rule_indices!(node::AbstractGrammarConstraint,grammar::AbstractGrammar)
-
-Used to update constraints when the grammar changes, e.g., by adding rules or merging grammars.
-
-# Arguments
-- `c`: The `AbstractGrammarConstraint` to be updated
-- `grammar`: The grammar that changed
-
-# Notes
-Individual implementations may not use all provided arguments.
-"""
-function HerbCore.update_rule_indices!(c::AbstractGrammarConstraint,
-    grammar::AbstractGrammar
-)
-    error("update_rule_indices! not implemented for constraint type $(typeof(c))")
-end
-
-"""
-    function update_rule_indices!(node::AbstractGrammarConstraint,n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer}, constraints::Vector{AbstractConstraint})
-
-Used to update constraints when the grammar changes, e.g., by adding rules or merging grammars. 
-
-# Arguments
-- `c`: The `AbstractGrammarConstraint` to be updated
-- `n_rules`: The new number of rules in the grammar
-- `mapping`: Dictionary mapping old rule indices to new rule indices
-- `constraints`: List of grammar constraints
-
-# Notes
-Individual implementations may not use all provided arguments.
-"""
-function HerbCore.update_rule_indices!(c::AbstractGrammarConstraint,
-    n_rules::Integer,
-    mapping::AbstractDict{<:Integer,<:Integer},
-    constraints::Vector{<:AbstractConstraint}
-)
-    error("update_rule_indices! not implemented for constraint type $(typeof(c))")
-end
-
-"""
-    function update_rule_indices!(node::AbstractGrammarConstraint,grammar::AbstractGrammar, mapping::AbstractDict{<:Integer,<:Integer})
-
-Used to update constraints when the grammar changes, e.g., by adding rules or merging grammars. 
-
-# Arguments
-- `c`: The `AbstractGrammarConstraint` to be updated
-- `grammar`: The grammar that changed
-- `mapping`: Dictionary mapping old rule indices to new rule indices
-
-# Notes
-Individual implementations may not use all provided arguments.
-"""
-function HerbCore.update_rule_indices!(c::AbstractGrammarConstraint,
-    grammar::AbstractGrammar,
-    mapping::AbstractDict{<:Integer,<:Integer}
-)
-    error("update_rule_indices! not implemented for constraint type $(typeof(c))")
-end
-
 """
     abstract type AbstractLocalConstraint <: AbstractConstraint
 
@@ -157,7 +78,6 @@ include("grammarconstraints/contains.jl")
 include("grammarconstraints/contains_subtree.jl")
 include("grammarconstraints/forbidden_sequence.jl")
 include("grammarconstraints/unique.jl")
-include("grammarconstraints/utils.jl")
 
 export
     AbstractGrammarConstraint,

--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -76,6 +76,7 @@ include("grammarconstraints/contains.jl")
 include("grammarconstraints/contains_subtree.jl")
 include("grammarconstraints/forbidden_sequence.jl")
 include("grammarconstraints/unique.jl")
+include("grammarconstraints/utils.jl")
 
 export
     AbstractGrammarConstraint,
@@ -146,6 +147,8 @@ export
 
     #state fixed shaped hole
     StateHole,
-    freeze_state
+    freeze_state,
+
+    update_rule_indices!
 
 end # module HerbConstraints

--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -50,7 +50,8 @@ Individual implementations may not use all provided arguments.
 """
 function update_rule_indices!(c::AbstractGrammarConstraint,
     n_rules::Integer,
-    mapping::AbstractDict{<:Integer,<:Integer}
+    mapping::AbstractDict{<:Integer,<:Integer},
+    constraints::Vector{<:AbstractConstraint}
 )
     error("update_rule_indices! not implemented for constraint type $(typeof(c))")
 end

--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -5,7 +5,6 @@ using HerbGrammar
 using DataStructures
 using MLStyle
 using TimerOutputs
-using AutoHashEquals
 
 
 """

--- a/src/domainrulenode.jl
+++ b/src/domainrulenode.jl
@@ -25,3 +25,52 @@ DomainRuleNode(grammar::AbstractGrammar, rules::Vector{Int}) = DomainRuleNode(gr
 
 #DomainRuleNode(get_domain(grammar, sym), [])
 DomainRuleNode(domain::BitVector) = DomainRuleNode(domain, [])
+
+"""
+Processes and updates current node in a tree as required when grammar size changes.
+For `DomainRuleNode` instances, this function resizes the domain by adding zeros.
+Recursively processes all child nodes of the tree.
+
+# Arguments
+- `node`: The current `DomainRuleNode` being processed
+- `n_rules`: The new number of rules in the grammar
+"""
+function HerbCore.update_rule_indices!(node::DomainRuleNode, n_rules::Integer)
+    append!(node.domain, falses(n_rules - length(node.domain)))
+    for child in node.children
+        HerbCore.update_rule_indices!(child, n_rules)
+    end
+end
+
+"""
+	update_rule_indices!(node::DomainRuleNode, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer})
+
+Processes and updates current node in a tree as required when grammar size changes.
+For `DomainRuleNode` instances, this function remaps the rule indices based on `mapping` and resizes the domain by adding zeros.
+Recursively processes all child nodes of the tree.
+
+# Arguments
+- `node`: The current `DomainRuleNode` being processed
+- `n_rules`: The new number of rules in the grammar
+- `mapping`: Dictionary mapping old rule indices to new rule indices
+"""
+function HerbCore.update_rule_indices!(
+    node::DomainRuleNode,
+    n_rules::Integer,
+    mapping::AbstractDict{<:Integer,<:Integer},
+)
+    # resize domain 
+    HerbCore.update_rule_indices!(node, n_rules)
+    # remap rule indices
+    rules = findall(node.domain)
+    for r in rules
+        if haskey(mapping, r)
+            node.domain[r] = false
+            node.domain[mapping[r]] = true
+        end
+    end
+    children = get_children(node)
+    for child in children
+        HerbCore.update_rule_indices!(child, n_rules, mapping)
+    end
+end

--- a/src/domainrulenode.jl
+++ b/src/domainrulenode.jl
@@ -27,15 +27,19 @@ DomainRuleNode(grammar::AbstractGrammar, rules::Vector{Int}) = DomainRuleNode(gr
 DomainRuleNode(domain::BitVector) = DomainRuleNode(domain, [])
 
 """
-Processes and updates current node in a tree as required when grammar size changes.
-For `DomainRuleNode` instances, this function resizes the domain by adding zeros.
-Recursively processes all child nodes of the tree.
+    update_rule_indices!(node::DomainRuleNode, n_rules::Integer)
+
+Updates the `DomainRuleNode` by resizing the domain vector to `n_rules`. 
+Errors if the length of the domain vector exceeds new `n_rules`.
 
 # Arguments
 - `node`: The current `DomainRuleNode` being processed
 - `n_rules`: The new number of rules in the grammar
 """
 function HerbCore.update_rule_indices!(node::DomainRuleNode, n_rules::Integer)
+    if length(node.domain) > n_rules
+        error("Length domain vector $(length(node.domain)) exceeds the number of grammar rules $(n_rules).")
+    end
     append!(node.domain, falses(n_rules - length(node.domain)))
     for child in node.children
         HerbCore.update_rule_indices!(child, n_rules)
@@ -45,9 +49,8 @@ end
 """
 	update_rule_indices!(node::DomainRuleNode, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer})
 
-Processes and updates current node in a tree as required when grammar size changes.
-For `DomainRuleNode` instances, this function remaps the rule indices based on `mapping` and resizes the domain by adding zeros.
-Recursively processes all child nodes of the tree.
+Updates the `DomainRuleNode` by resizing the domain vector to `n_rules` and remapping rule indices based `mapping`. 
+Errors if the length of the domain vector exceeds new `n_rules`.
 
 # Arguments
 - `node`: The current `DomainRuleNode` being processed

--- a/src/grammarconstraints/contains.jl
+++ b/src/grammarconstraints/contains.jl
@@ -24,3 +24,39 @@ function check_tree(c::Contains, tree::AbstractRuleNode)::Bool
     end
     return any(check_tree(c, child) for child ∈ get_children(tree))
 end
+
+
+"""
+	update_rule_indices!(c::Contains, n_rules::Integer)
+
+Updates a `Contains` constraint to reflect grammar changes. No operation is performed 
+as `Contains` constraints do not require updates for grammar rule changes.
+
+# Arguments
+- `c`: The `Contains` constraint to be updated
+- `n_rules`: The new number of rules in the grammar
+"""
+function update_rule_indices!(c::Contains, n_rules::Integer)
+    # no update required
+end
+
+"""
+    update_rule_indices!(c::Contains, n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer}, constraints::Vector{AbstractConstraint})
+
+Updates the `Contains` constraint to reflect grammar changes by replacing it with a new 
+`Contains` constraint using the mapped rule index.
+
+# Arguments
+- `c`: The `Contains` constraint to be updated
+- `n_rules`: The new number of rules in the grammar  
+- `mapping`: Dictionary mapping old rule indices to new rule indices
+- `constraints`: Vector of grammar constraints containing the constraint to update
+"""
+function update_rule_indices!(c::Contains,
+    n_rules::Integer,
+    mapping::AbstractDict{<:Integer,<:Integer},
+    constraints::Vector{AbstractConstraint})
+    index = findfirst(x -> x == c, c_vector) # assumes no duplicate constraints => TODO: can we assume this?
+    new_rule = _get_new_index(c.rule, mapping)
+    c_vector[index] = Contains(new_rule)
+end

--- a/src/grammarconstraints/contains.jl
+++ b/src/grammarconstraints/contains.jl
@@ -66,10 +66,12 @@ Updates the `Contains` constraint to reflect grammar changes by replacing it wit
 - `mapping`: Dictionary mapping old rule indices to new rule indices
 - `constraints`: Vector of grammar constraints containing the constraint to update
 """
-function HerbCore.update_rule_indices!(c::Contains,
+function HerbCore.update_rule_indices!(
+    c::Contains,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
-    constraints::Vector{<:AbstractConstraint})
+    constraints::Vector{<:AbstractConstraint}
+)
     index = only(findall(x -> x == c, constraints))
     new_rule = _get_new_index(c.rule, mapping)
     constraints[index] = Contains(new_rule)

--- a/src/grammarconstraints/contains.jl
+++ b/src/grammarconstraints/contains.jl
@@ -41,7 +41,7 @@ function update_rule_indices!(c::Contains, n_rules::Integer)
 end
 
 """
-    update_rule_indices!(c::Contains, n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer}, constraints::Vector{AbstractConstraint})
+    update_rule_indices!(c::Contains, n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer}, constraints::Vector{<:AbstractConstraint})
 
 Updates the `Contains` constraint to reflect grammar changes by replacing it with a new 
 `Contains` constraint using the mapped rule index.
@@ -55,8 +55,8 @@ Updates the `Contains` constraint to reflect grammar changes by replacing it wit
 function update_rule_indices!(c::Contains,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
-    constraints::Vector{AbstractConstraint})
-    index = findfirst(x -> x == c, c_vector) # assumes no duplicate constraints => TODO: can we assume this?
+    constraints::Vector{<:AbstractConstraint})
+    index = findfirst(x -> x == c, constraints) # assumes no duplicate constraints => TODO: can we assume this?
     new_rule = _get_new_index(c.rule, mapping)
-    c_vector[index] = Contains(new_rule)
+    constraints[index] = Contains(new_rule)
 end

--- a/src/grammarconstraints/contains.jl
+++ b/src/grammarconstraints/contains.jl
@@ -70,7 +70,7 @@ function HerbCore.update_rule_indices!(c::Contains,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
     constraints::Vector{<:AbstractConstraint})
-    index = findfirst(x -> x == c, constraints) # assumes no duplicate constraints => TODO: can we assume this?
+    index = only(findall(x -> x == c, constraints))
     new_rule = _get_new_index(c.rule, mapping)
     constraints[index] = Contains(new_rule)
 end

--- a/src/grammarconstraints/contains.jl
+++ b/src/grammarconstraints/contains.jl
@@ -29,28 +29,33 @@ end
 """
 	update_rule_indices!(c::Contains, n_rules::Integer)
 
-Updates a `Contains` constraint to reflect grammar changes. No operation is performed 
-as `Contains` constraints do not require updates for grammar rule changes.
+Updates a `Contains` constraint to reflect grammar changes. Errors if rule index exceeds new `n_rules`.
 
 # Arguments
 - `c`: The `Contains` constraint to be updated
 - `n_rules`: The new number of rules in the grammar
 """
 function HerbCore.update_rule_indices!(c::Contains, n_rules::Integer)
+    if c.rule > n_rules
+        error("Rule index $(c.rule) exceeds the number of grammar rules ($n_rules).")
+    end
     # no update required
 end
 
 """
 	update_rule_indices!(c::Contains, grammar::AbstractGrammar)
 
-Updates a `Contains` constraint to reflect grammar changes. No operation is performed 
-as `Contains` constraints do not require updates for grammar rule changes.
+Updates the `Contains` constraint as required when grammar size changes. Errors if the rule index exceeds number of grammar rules.
 
 # Arguments
 - `c`: The `Contains` constraint to be updated
 - `grammar`: The grammar that changed
 """
 function HerbCore.update_rule_indices!(c::Contains, grammar::AbstractGrammar)
+    n_rules = length(grammar.rules)
+    if c.rule > n_rules
+        error("Rule index $(c.rule) exceeds the number of grammar rules ($n_rules).")
+    end
     # no update required
 end
 
@@ -72,8 +77,11 @@ function HerbCore.update_rule_indices!(
     mapping::AbstractDict{<:Integer,<:Integer},
     constraints::Vector{<:AbstractConstraint}
 )
+    if c.rule > n_rules
+        error("Rule index $(c.rule) exceeds the number of grammar rules ($n_rules).")
+    end
     index = only(findall(x -> x == c, constraints))
-    new_rule = _get_new_index(c.rule, mapping)
+    new_rule = get(mapping, c.rule, c.rule) # keep rule index if no matching entry found in mapping
     constraints[index] = Contains(new_rule)
 end
 

--- a/src/grammarconstraints/contains.jl
+++ b/src/grammarconstraints/contains.jl
@@ -36,7 +36,21 @@ as `Contains` constraints do not require updates for grammar rule changes.
 - `c`: The `Contains` constraint to be updated
 - `n_rules`: The new number of rules in the grammar
 """
-function update_rule_indices!(c::Contains, n_rules::Integer)
+function HerbCore.update_rule_indices!(c::Contains, n_rules::Integer)
+    # no update required
+end
+
+"""
+	update_rule_indices!(c::Contains, grammar::AbstractGrammar)
+
+Updates a `Contains` constraint to reflect grammar changes. No operation is performed 
+as `Contains` constraints do not require updates for grammar rule changes.
+
+# Arguments
+- `c`: The `Contains` constraint to be updated
+- `grammar`: The grammar that changed
+"""
+function HerbCore.update_rule_indices!(c::Contains, grammar::AbstractGrammar)
     # no update required
 end
 
@@ -52,11 +66,28 @@ Updates the `Contains` constraint to reflect grammar changes by replacing it wit
 - `mapping`: Dictionary mapping old rule indices to new rule indices
 - `constraints`: Vector of grammar constraints containing the constraint to update
 """
-function update_rule_indices!(c::Contains,
+function HerbCore.update_rule_indices!(c::Contains,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
     constraints::Vector{<:AbstractConstraint})
     index = findfirst(x -> x == c, constraints) # assumes no duplicate constraints => TODO: can we assume this?
     new_rule = _get_new_index(c.rule, mapping)
     constraints[index] = Contains(new_rule)
+end
+
+"""
+    update_rule_indices!(c::Contains, grammar::AbstractGrammar, mapping::AbstractDict{<:Integer,<:Integer})
+
+Updates the `Contains` constraint to reflect grammar changes by replacing it with a new 
+`Contains` constraint using the mapped rule index.
+
+# Arguments
+- `c`: The `Contains` constraint to be updated
+- `grammar`: The grammar that changed  
+- `mapping`: Dictionary mapping old rule indices to new rule indices
+"""
+function HerbCore.update_rule_indices!(c::Contains,
+    grammar::AbstractGrammar,
+    mapping::AbstractDict{<:Integer,<:Integer})
+    HerbCore.update_rule_indices!(c, length(grammar.rules), mapping, grammar.constraints)
 end

--- a/src/grammarconstraints/contains_subtree.jl
+++ b/src/grammarconstraints/contains_subtree.jl
@@ -6,7 +6,7 @@ This [`AbstractGrammarConstraint`] enforces that a given `subtree` appears in th
 !!! warning:
     This constraint can only be propagated by the UniformSolver
 """
-struct ContainsSubtree <: AbstractGrammarConstraint
+@auto_hash_equals struct ContainsSubtree <: AbstractGrammarConstraint
     tree::AbstractRuleNode
 end
 

--- a/src/grammarconstraints/contains_subtree.jl
+++ b/src/grammarconstraints/contains_subtree.jl
@@ -6,7 +6,7 @@ This [`AbstractGrammarConstraint`] enforces that a given `subtree` appears in th
 !!! warning:
     This constraint can only be propagated by the UniformSolver
 """
-@auto_hash_equals struct ContainsSubtree <: AbstractGrammarConstraint
+struct ContainsSubtree <: AbstractGrammarConstraint
     tree::AbstractRuleNode
 end
 

--- a/src/grammarconstraints/contains_subtree.jl
+++ b/src/grammarconstraints/contains_subtree.jl
@@ -29,3 +29,43 @@ function check_tree(c::ContainsSubtree, tree::AbstractRuleNode)::Bool
     end
     return any(check_tree(c, child) for child ∈ get_children(tree))
 end
+
+"""
+	update_rule_indices!(c::ContainsSubtree, n_rules::Integer)
+
+Updates the `ContainsSubtree` constraint to reflect grammar changes. Calls `HerbCore.update_rule_indices!` its `tree` field.
+
+# Arguments
+- `c`: The `ContainsSubtree` constraint to be updated.
+- `n_rules`: The new number of rules in the grammar.
+
+# Notes
+This function ensures that every node of the `tree` field of the `ContainsSubtree` constraint is updated as required.
+"""
+function update_rule_indices!(
+    c::ContainsSubtree,
+    n_rules::Integer,
+)
+    HerbCore.update_rule_indices!(c.tree, n_rules)
+end
+
+"""
+	update_rule_indices!(c::ContainsSubtree, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer})
+
+Updates the `ContainsSubtree` constraint to reflect grammar changes. Calls `HerbCore.update_rule_indices!` its `tree` field.
+
+# Arguments
+- `c`: The `ContainsSubtree` constraint to be updated.
+- `n_rules`: The new number of rules in the grammar.
+- `mapping`: A dictionary mapping old rule indices to new rule indices
+
+# Notes
+This function ensures that every node of the `tree` field of the `ContainsSubtree` constraint is updated as required.
+"""
+function update_rule_indices!(
+    c::ContainsSubtree,
+    n_rules::Integer,
+    mapping::AbstractDict{<:Integer,<:Integer},
+)
+    HerbCore.update_rule_indices!(c.tree, n_rules, mapping)
+end

--- a/src/grammarconstraints/contains_subtree.jl
+++ b/src/grammarconstraints/contains_subtree.jl
@@ -38,9 +38,6 @@ Updates the `ContainsSubtree` constraint to reflect grammar changes by calling `
 # Arguments
 - `c`: The `ContainsSubtree` constraint to be updated
 - `n_rules`: The new number of rules in the grammar
-
-# Notes
-Ensures that every node of the `tree` field is updated as required.
 """
 function HerbCore.update_rule_indices!(
     c::ContainsSubtree,
@@ -57,9 +54,6 @@ Updates the `ContainsSubtree` constraint to reflect grammar changes by calling `
 # Arguments
 - `c`: The `ContainsSubtree` constraint to be updated
 - `grammar`: The grammar that changed
-
-# Notes
-Ensures that every node of the `tree` field is updated as required.
 """
 function HerbCore.update_rule_indices!(
     c::ContainsSubtree,
@@ -69,7 +63,7 @@ function HerbCore.update_rule_indices!(
 end
 
 """
-	update_rule_indices!(c::ContainsSubtree, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, constraints::Vector{<:AbstractConstraint})
+	update_rule_indices!(c::ContainsSubtree, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, ::Vector{<:AbstractConstraint})
 
 Updates the `ContainsSubtree` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
 
@@ -77,16 +71,12 @@ Updates the `ContainsSubtree` constraint to reflect grammar changes by calling `
 - `c`: The `ContainsSubtree` to be updated
 - `n_rules`: The new number of rules in the grammar
 - `mapping`: Dictionary mapping old rule indices to new rule indices
-- `constraints`: List of grammar constraints
-
-# Notes
-Ensures that every node of the `tree` field is updated as required.
 """
 function HerbCore.update_rule_indices!(
     c::ContainsSubtree,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
-    constraints::Vector{<:AbstractConstraint}
+    ::Vector{<:AbstractConstraint}
 )
     HerbCore.update_rule_indices!(c.tree, n_rules, mapping)
 end
@@ -100,9 +90,6 @@ Updates the `ContainsSubtree` constraint to reflect grammar changes by calling `
 - `c`: The `ContainsSubtree` to be updated
 - `grammar`: The grammar that changed
 - `mapping`: Dictionary mapping old rule indices to new rule indices
-
-# Notes
-Ensures that every node of the `tree` field is updated as required.
 """
 function HerbCore.update_rule_indices!(
     c::ContainsSubtree,

--- a/src/grammarconstraints/contains_subtree.jl
+++ b/src/grammarconstraints/contains_subtree.jl
@@ -33,14 +33,14 @@ end
 """
 	update_rule_indices!(c::ContainsSubtree, n_rules::Integer)
 
-Updates the `ContainsSubtree` constraint to reflect grammar changes. Calls `HerbCore.update_rule_indices!` its `tree` field.
+Updates the `ContainsSubtree` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
 
 # Arguments
-- `c`: The `ContainsSubtree` constraint to be updated.
-- `n_rules`: The new number of rules in the grammar.
+- `c`: The `ContainsSubtree` constraint to be updated
+- `n_rules`: The new number of rules in the grammar
 
 # Notes
-This function ensures that every node of the `tree` field of the `ContainsSubtree` constraint is updated as required.
+Ensures that every node of the `tree` field is updated as required.
 """
 function update_rule_indices!(
     c::ContainsSubtree,
@@ -50,22 +50,24 @@ function update_rule_indices!(
 end
 
 """
-	update_rule_indices!(c::ContainsSubtree, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer})
+	update_rule_indices!(c::ContainsSubtree, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, constraints::Vector{AbstractConstraint})
 
-Updates the `ContainsSubtree` constraint to reflect grammar changes. Calls `HerbCore.update_rule_indices!` its `tree` field.
+Updates the `ContainsSubtree` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
 
 # Arguments
-- `c`: The `ContainsSubtree` constraint to be updated.
-- `n_rules`: The new number of rules in the grammar.
-- `mapping`: A dictionary mapping old rule indices to new rule indices
+- `c`: The `ContainsSubtree` to be updated
+- `n_rules`: The new number of rules in the grammar
+- `mapping`: Dictionary mapping old rule indices to new rule indices
+- `constraints`: List of grammar constraints
 
 # Notes
-This function ensures that every node of the `tree` field of the `ContainsSubtree` constraint is updated as required.
+Ensures that every node of the `tree` field is updated as required.
 """
 function update_rule_indices!(
     c::ContainsSubtree,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
+    constraints::Vector{AbstractConstraint}
 )
     HerbCore.update_rule_indices!(c.tree, n_rules, mapping)
 end

--- a/src/grammarconstraints/contains_subtree.jl
+++ b/src/grammarconstraints/contains_subtree.jl
@@ -50,7 +50,7 @@ function update_rule_indices!(
 end
 
 """
-	update_rule_indices!(c::ContainsSubtree, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, constraints::Vector{AbstractConstraint})
+	update_rule_indices!(c::ContainsSubtree, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, constraints::Vector{<:AbstractConstraint})
 
 Updates the `ContainsSubtree` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
 
@@ -67,7 +67,7 @@ function update_rule_indices!(
     c::ContainsSubtree,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
-    constraints::Vector{AbstractConstraint}
+    constraints::Vector{<:AbstractConstraint}
 )
     HerbCore.update_rule_indices!(c.tree, n_rules, mapping)
 end

--- a/src/grammarconstraints/contains_subtree.jl
+++ b/src/grammarconstraints/contains_subtree.jl
@@ -42,11 +42,30 @@ Updates the `ContainsSubtree` constraint to reflect grammar changes by calling `
 # Notes
 Ensures that every node of the `tree` field is updated as required.
 """
-function update_rule_indices!(
+function HerbCore.update_rule_indices!(
     c::ContainsSubtree,
     n_rules::Integer,
 )
     HerbCore.update_rule_indices!(c.tree, n_rules)
+end
+
+"""
+	update_rule_indices!(c::ContainsSubtree, grammar::AbstractGrammar)
+
+Updates the `ContainsSubtree` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
+
+# Arguments
+- `c`: The `ContainsSubtree` constraint to be updated
+- `grammar`: The grammar that changed
+
+# Notes
+Ensures that every node of the `tree` field is updated as required.
+"""
+function HerbCore.update_rule_indices!(
+    c::ContainsSubtree,
+    grammar::AbstractGrammar,
+)
+    HerbCore.update_rule_indices!(c, length(grammar.rules))
 end
 
 """
@@ -63,11 +82,32 @@ Updates the `ContainsSubtree` constraint to reflect grammar changes by calling `
 # Notes
 Ensures that every node of the `tree` field is updated as required.
 """
-function update_rule_indices!(
+function HerbCore.update_rule_indices!(
     c::ContainsSubtree,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
     constraints::Vector{<:AbstractConstraint}
 )
     HerbCore.update_rule_indices!(c.tree, n_rules, mapping)
+end
+
+"""
+    update_rule_indices!(c::ContainsSubtree, grammar::AbstractGrammar, mapping::AbstractDict{<:Integer, <:Integer})
+
+Updates the `ContainsSubtree` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
+
+# Arguments
+- `c`: The `ContainsSubtree` to be updated
+- `grammar`: The grammar that changed
+- `mapping`: Dictionary mapping old rule indices to new rule indices
+
+# Notes
+Ensures that every node of the `tree` field is updated as required.
+"""
+function HerbCore.update_rule_indices!(
+    c::ContainsSubtree,
+    grammar::AbstractGrammar,
+    mapping::AbstractDict{<:Integer,<:Integer},
+)
+    HerbCore.update_rule_indices!(c, length(grammar.rules), mapping, grammar.constraints)
 end

--- a/src/grammarconstraints/forbidden.jl
+++ b/src/grammarconstraints/forbidden.jl
@@ -27,8 +27,12 @@ function on_new_node(solver::Solver, c::Forbidden, path::Vector{Int})
     #minor optimization: prevent the first hardfail (https://github.com/orgs/Herb-AI/projects/6/views/1?pane=issue&itemId=55570518)
     if c.tree isa RuleNode
         @match get_node_at_location(solver, path) begin
-            hole::AbstractHole => if !hole.domain[c.tree.ind] return end
-            node::RuleNode => if node.ind != c.tree.ind return end
+            hole::AbstractHole => if !hole.domain[c.tree.ind]
+                return
+            end
+            node::RuleNode => if node.ind != c.tree.ind
+                return
+            end
         end
     end
     post!(solver, LocalForbidden(path, c.tree))
@@ -41,10 +45,52 @@ Checks if the given [`AbstractRuleNode`](@ref) tree abides the [`Forbidden`](@re
 """
 function check_tree(c::Forbidden, tree::AbstractRuleNode)::Bool
     @match pattern_match(tree, c.tree) begin
-      ::PatternMatchHardFail => ()
-      ::PatternMatchSoftFail => ()
-      ::PatternMatchSuccess => return false
-      ::PatternMatchSuccessWhenHoleAssignedTo => ()
+        ::PatternMatchHardFail => ()
+        ::PatternMatchSoftFail => ()
+        ::PatternMatchSuccess => return false
+        ::PatternMatchSuccessWhenHoleAssignedTo => ()
     end
     return all(check_tree(c, child) for child ∈ tree.children)
+end
+
+"""
+    update_rule_indices!(c::Forbidden, n_rules::Integer)
+
+Interface function for updating a `Forbidden` constraint to reflect grammar changes.
+
+# Arguments
+- `c`: The `Forbidden` constraint to be updated.
+- `n_rules`: The new number of rules in the grammar.
+
+# Notes
+This function does not perform any operations because no updates are required for this specific interface.
+"""
+func
+function update_rule_indices!(
+    c::Forbidden,
+    n_rules::Integer,
+)
+    # no update required
+    # HerbCore.update_rule_indices!(c.tree, n_rules) # TODO: check if correct
+end
+
+"""
+	update_rule_indices!(c::Forbidden, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer})
+
+Updates the a `Forbidden` constraint to reflect grammar changes. Calls `HerbCore.update_rule_indices!` its `tree` field.
+
+# Arguments
+- `c`: `Forbidden` constraint.
+- `n_rules`: The new number of rules in the grammar.
+- `mapping`: Dictionary mapping old rule indices to new rule indices
+
+# Notes
+This function ensures that every node of the `tree` field of the `Forbidden` constraint is updated as required.
+"""
+function update_rule_indices!(
+    c::Forbidden,
+    n_rules::Integer,
+    mapping::AbstractDict{<:Integer,<:Integer},
+)
+    HerbCore.update_rule_indices!(c.tree, n_rules, mapping)
 end

--- a/src/grammarconstraints/forbidden.jl
+++ b/src/grammarconstraints/forbidden.jl
@@ -65,9 +65,6 @@ Updates the `Forbidden` constraint to reflect grammar changes by calling `HerbCo
 # Arguments
 - `c`: The `Forbidden` constraint to be updated.
 - `n_rules`: The new number of rules in the grammar.
-
-# Notes
-Ensures that every node of the `tree` field is updated as required.
 """
 function HerbCore.update_rule_indices!(
     c::Forbidden,
@@ -84,9 +81,6 @@ Updates the `Forbidden` constraint to reflect grammar changes by calling `HerbCo
 # Arguments
 - `c`: The `Forbidden` constraint to be updated.
 - `grammar`: The new number of rules in the grammar.
-
-# Notes
-Ensures that every node of the `tree` field is updated as required.
 """
 function HerbCore.update_rule_indices!(
     c::Forbidden,
@@ -96,7 +90,7 @@ function HerbCore.update_rule_indices!(
 end
 
 """
-	update_rule_indices!(c::Forbidden, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, constraints::Vector{<:AbstractConstraint})
+	update_rule_indices!(c::Forbidden, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, ::Vector{<:AbstractConstraint})
 
 Updates the `Forbidden` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
 
@@ -104,16 +98,12 @@ Updates the `Forbidden` constraint to reflect grammar changes by calling `HerbCo
 - `c`: The `Forbidden` constraint to be updated
 - `n_rules`: The new number of rules in the grammar  
 - `mapping`: Dictionary mapping old rule indices to new rule indices
-- `constraints`: Vector of grammar constraints containing the constraint to update
-
-# Notes
-Ensures that every node of the `tree` field is updated as required.
 """
 function HerbCore.update_rule_indices!(
     c::Forbidden,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
-    constraints::Vector{<:AbstractConstraint}
+    ::Vector{<:AbstractConstraint}
 )
     HerbCore.update_rule_indices!(c.tree, n_rules, mapping)
 end
@@ -127,9 +117,6 @@ Updates the `Forbidden` constraint to reflect grammar changes by calling `HerbCo
 - `c`: The `Forbidden` constraint to be updated
 - `grammar`: The grammar that changed
 - `mapping`: Dictionary mapping old rule indices to new rule indices
-
-# Notes
-Ensures that every node of the `tree` field is updated as required.
 """
 function HerbCore.update_rule_indices!(
     c::Forbidden,

--- a/src/grammarconstraints/forbidden.jl
+++ b/src/grammarconstraints/forbidden.jl
@@ -3,14 +3,13 @@
 
 This [`AbstractGrammarConstraint`] forbids any subtree that matches the pattern given by `tree` to be generated.
 A pattern is a tree of [`AbstractRuleNode`](@ref)s. 
-Such a node can either be a [`RuleNode`](@ref), which contains a rule index corresponding to the 
-rule index in the [`AbstractGrammar`](@ref) and the appropriate number of children, similar to [`RuleNode`](@ref)s.
-It can also contain a [`VarNode`](@ref), which contains a single identifier symbol.
-A [`VarNode`](@ref) can match any subtree, but if there are multiple instances of the same
-variable in the pattern, the matched subtrees must be identical.
-Any rule in the domain that makes the match attempt successful is removed.
 
-For example, consider the tree `1(a, 2(b, 3(c, 4))))`:
+# Example
+
+A node in the tree can be of any type `<:AbstractRuleNode`. For example, a [`RuleNode`](@ref), which contains a rule index corresponding to the 
+rule index in the [`AbstractGrammar`](@ref) and the appropriate number of children, or a [`VarNode`](@ref), which contains a single identifier symbol.
+
+Let's consider the tree `1(a, 2(b, 3(c, 4))))`:
 
 - `Forbidden(RuleNode(3, [RuleNode(5), RuleNode(4)]))` forbids `c` to be filled with `5`.
 - `Forbidden(RuleNode(3, [VarNode(:v), RuleNode(4)]))` forbids `c` to be filled, since a [`VarNode`] can 
@@ -18,6 +17,11 @@ For example, consider the tree `1(a, 2(b, 3(c, 4))))`:
     Therefore, this tree invalid.
 - `Forbidden(RuleNode(3, [VarNode(:v), VarNode(:v)]))` forbids `c` to be filled with `4`, since that would 
     make both assignments to `v` equal, which causes a successful match.
+
+A [`VarNode`](@ref) can match any subtree, but if there are multiple instances of the same
+variable in the pattern, the matched subtrees must be identical.
+Any rule in the domain that makes the match attempt successful is removed.
+
 """
 struct Forbidden <: AbstractGrammarConstraint
     tree::AbstractRuleNode
@@ -56,22 +60,21 @@ end
 """
     update_rule_indices!(c::Forbidden, n_rules::Integer)
 
-Interface function for updating a `Forbidden` constraint to reflect grammar changes.
+Updates the `Forbidden` constraint to reflect grammar changes. Calls `HerbCore.update_rule_indices!` its `tree` field.
 
 # Arguments
 - `c`: The `Forbidden` constraint to be updated.
 - `n_rules`: The new number of rules in the grammar.
 
 # Notes
-This function does not perform any operations because no updates are required for this specific interface.
+This function ensures that every node of the `tree` field of the `Forbidden` constraint is updated as required.
 """
 func
 function update_rule_indices!(
     c::Forbidden,
     n_rules::Integer,
 )
-    # no update required
-    # HerbCore.update_rule_indices!(c.tree, n_rules) # TODO: check if correct
+    HerbCore.update_rule_indices!(c.tree, n_rules)
 end
 
 """

--- a/src/grammarconstraints/forbidden.jl
+++ b/src/grammarconstraints/forbidden.jl
@@ -69,11 +69,30 @@ Updates the `Forbidden` constraint to reflect grammar changes by calling `HerbCo
 # Notes
 Ensures that every node of the `tree` field is updated as required.
 """
-function update_rule_indices!(
+function HerbCore.update_rule_indices!(
     c::Forbidden,
     n_rules::Integer,
 )
     HerbCore.update_rule_indices!(c.tree, n_rules)
+end
+
+"""
+    update_rule_indices!(c::Forbidden, grammar::AbstractGrammar)
+
+Updates the `Forbidden` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
+
+# Arguments
+- `c`: The `Forbidden` constraint to be updated.
+- `grammar`: The new number of rules in the grammar.
+
+# Notes
+Ensures that every node of the `tree` field is updated as required.
+"""
+function HerbCore.update_rule_indices!(
+    c::Forbidden,
+    grammar::AbstractGrammar,
+)
+    HerbCore.update_rule_indices!(c.tree, length(grammar.rules))
 end
 
 """
@@ -90,11 +109,32 @@ Updates the `Forbidden` constraint to reflect grammar changes by calling `HerbCo
 # Notes
 Ensures that every node of the `tree` field is updated as required.
 """
-function update_rule_indices!(
+function HerbCore.update_rule_indices!(
     c::Forbidden,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
     constraints::Vector{<:AbstractConstraint}
 )
     HerbCore.update_rule_indices!(c.tree, n_rules, mapping)
+end
+
+"""
+	update_rule_indices!(c::Forbidden, grammar::AbstractGrammar, mapping::AbstractDict{<:Integer, <:Integer})
+
+Updates the `Forbidden` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
+
+# Arguments
+- `c`: The `Forbidden` constraint to be updated
+- `grammar`: The grammar that changed
+- `mapping`: Dictionary mapping old rule indices to new rule indices
+
+# Notes
+Ensures that every node of the `tree` field is updated as required.
+"""
+function HerbCore.update_rule_indices!(
+    c::Forbidden,
+    grammar::AbstractGrammar,
+    mapping::AbstractDict{<:Integer,<:Integer},
+)
+    HerbCore.update_rule_indices!(c, length(grammar.rules), mapping, grammar.constraints)
 end

--- a/src/grammarconstraints/forbidden.jl
+++ b/src/grammarconstraints/forbidden.jl
@@ -60,16 +60,15 @@ end
 """
     update_rule_indices!(c::Forbidden, n_rules::Integer)
 
-Updates the `Forbidden` constraint to reflect grammar changes. Calls `HerbCore.update_rule_indices!` its `tree` field.
+Updates the `Forbidden` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
 
 # Arguments
 - `c`: The `Forbidden` constraint to be updated.
 - `n_rules`: The new number of rules in the grammar.
 
 # Notes
-This function ensures that every node of the `tree` field of the `Forbidden` constraint is updated as required.
+Ensures that every node of the `tree` field is updated as required.
 """
-func
 function update_rule_indices!(
     c::Forbidden,
     n_rules::Integer,
@@ -78,17 +77,18 @@ function update_rule_indices!(
 end
 
 """
-	update_rule_indices!(c::Forbidden, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer})
+	update_rule_indices!(c::Forbidden, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, constraints::Vector{AbstractConstraint})
 
-Updates the a `Forbidden` constraint to reflect grammar changes. Calls `HerbCore.update_rule_indices!` its `tree` field.
+Updates the `Forbidden` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
 
 # Arguments
-- `c`: `Forbidden` constraint.
-- `n_rules`: The new number of rules in the grammar.
+- `c`: The `Forbidden` constraint to be updated
+- `n_rules`: The new number of rules in the grammar  
 - `mapping`: Dictionary mapping old rule indices to new rule indices
+- `constraints`: Vector of grammar constraints containing the constraint to update
 
 # Notes
-This function ensures that every node of the `tree` field of the `Forbidden` constraint is updated as required.
+Ensures that every node of the `tree` field is updated as required.
 """
 function update_rule_indices!(
     c::Forbidden,

--- a/src/grammarconstraints/forbidden.jl
+++ b/src/grammarconstraints/forbidden.jl
@@ -77,7 +77,7 @@ function update_rule_indices!(
 end
 
 """
-	update_rule_indices!(c::Forbidden, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, constraints::Vector{AbstractConstraint})
+	update_rule_indices!(c::Forbidden, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, constraints::Vector{<:AbstractConstraint})
 
 Updates the `Forbidden` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
 
@@ -94,6 +94,7 @@ function update_rule_indices!(
     c::Forbidden,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
+    constraints::Vector{<:AbstractConstraint}
 )
     HerbCore.update_rule_indices!(c.tree, n_rules, mapping)
 end

--- a/src/grammarconstraints/forbidden_sequence.jl
+++ b/src/grammarconstraints/forbidden_sequence.jl
@@ -20,24 +20,24 @@ Consider the following paths from the root:
 - `[1, 99, 1, 2, 3]` is forbidden, as there is a subsequence that does not contain `99`
 """
 struct ForbiddenSequence <: AbstractGrammarConstraint
-	sequence::Vector{Int}
-	ignore_if::Vector{Int}
+    sequence::Vector{Int}
+    ignore_if::Vector{Int}
 end
 
-ForbiddenSequence(sequence::Vector{Int}; ignore_if = Vector{Int}()) =
-	ForbiddenSequence(sequence, ignore_if)
+ForbiddenSequence(sequence::Vector{Int}; ignore_if=Vector{Int}()) =
+    ForbiddenSequence(sequence, ignore_if)
 
 function on_new_node(solver::Solver, c::ForbiddenSequence, path::Vector{Int})
-	#minor optimization: prevent the first hardfail (https://github.com/orgs/Herb-AI/projects/6/views/1?pane=issue&itemId=55570518)
-	@match get_node_at_location(solver, path) begin
-		hole::AbstractHole => if !hole.domain[c.sequence[end]]
-			return
-		end
-		node::RuleNode => if node.ind != c.sequence[end]
-			return
-		end
-	end
-	post!(solver, LocalForbiddenSequence(path, c.sequence, c.ignore_if))
+    #minor optimization: prevent the first hardfail (https://github.com/orgs/Herb-AI/projects/6/views/1?pane=issue&itemId=55570518)
+    @match get_node_at_location(solver, path) begin
+        hole::AbstractHole => if !hole.domain[c.sequence[end]]
+            return
+        end
+        node::RuleNode => if node.ind != c.sequence[end]
+            return
+        end
+    end
+    post!(solver, LocalForbiddenSequence(path, c.sequence, c.ignore_if))
 end
 
 """
@@ -45,44 +45,76 @@ end
 
 Checks if the given [`AbstractRuleNode`](@ref) tree abides the [`ForbiddenSequence`](@ref) constraint.
 """
-function check_tree(c::ForbiddenSequence, tree::AbstractRuleNode; sequence_started = false)::Bool
-	@assert isfilled(tree) "check_tree does not support checking trees that contain holes. $(tree) is a hole."
+function check_tree(c::ForbiddenSequence, tree::AbstractRuleNode; sequence_started=false)::Bool
+    @assert isfilled(tree) "check_tree does not support checking trees that contain holes. $(tree) is a hole."
 
-	# attempt to start the sequence on the any node in the tree
-	if !sequence_started
-		for child ∈ tree.children
-			if !check_tree(c, child, sequence_started = false)
-				return false
-			end
-		end
-	end
+    # attempt to start the sequence on the any node in the tree
+    if !sequence_started
+        for child ∈ tree.children
+            if !check_tree(c, child, sequence_started=false)
+                return false
+            end
+        end
+    end
 
-	# add the current node to the current sequence if possible
-	if (get_rule(tree) == c.sequence[1])
-		remaining_sequence = c.sequence[2:end]
-		sequence_started = true
-	else
-		remaining_sequence = c.sequence
-	end
+    # add the current node to the current sequence if possible
+    if (get_rule(tree) == c.sequence[1])
+        remaining_sequence = c.sequence[2:end]
+        sequence_started = true
+    else
+        remaining_sequence = c.sequence
+    end
 
-	# the empty sequence is in any tree, so the constraint is violated
-	if isempty(remaining_sequence)
-		return false
-	end
+    # the empty sequence is in any tree, so the constraint is violated
+    if isempty(remaining_sequence)
+        return false
+    end
 
-	if sequence_started
-		# the sequence contains one of the `ignore_if` rules, and therefore is satisfied
-		if get_rule(tree) ∈ c.ignore_if
-			return true
-		end
+    if sequence_started
+        # the sequence contains one of the `ignore_if` rules, and therefore is satisfied
+        if get_rule(tree) ∈ c.ignore_if
+            return true
+        end
 
-		# continue the current sequence
-		smaller_constraint = ForbiddenSequence(remaining_sequence, c.ignore_if)
-		for child ∈ tree.children
-			if !check_tree(smaller_constraint, child, sequence_started = true)
-				return false
-			end
-		end
-	end
-	return true
+        # continue the current sequence
+        smaller_constraint = ForbiddenSequence(remaining_sequence, c.ignore_if)
+        for child ∈ tree.children
+            if !check_tree(smaller_constraint, child, sequence_started=true)
+                return false
+            end
+        end
+    end
+    return true
+end
+
+"""
+	update_rule_indices!(c::ForbiddenSequence, n_rules::Integer)
+
+Interface function for updating a `ForbiddenSequence` constraint to reflect grammar changes.
+
+# Arguments
+- `c`: The `ForbiddenSequence` constraint to be updated.
+- `n_rules`: The new number of rules in the grammar.
+
+# Notes
+This function does not perform any operations because no updates are required for this specific interface.
+"""
+function update_rule_indices!(c::ForbiddenSequence, n_rules::Integer)
+    # no update required
+end
+
+"""
+	update_rule_indices!(c::ForbiddenSequence, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer})
+
+Updates the rule indices of all fields of a `ForbiddenSequence` constraint based on the given `mapping`.
+
+# Arguments
+- `c`: `ForbiddenSequence` constraint.
+- `n_rules`: The new number of rules in the grammar (unused in this implementation).
+- `mapping`: Dictionary mapping old rule indices to new rule indices
+"""
+function update_rule_indices!(c::ForbiddenSequence, n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer})
+    c.sequence .= _get_new_index.(c.sequence, Ref(mapping))
+    c.ignore_if .= _get_new_index.(c.ignore_if, Ref(mapping))
+    return c
 end

--- a/src/grammarconstraints/forbidden_sequence.jl
+++ b/src/grammarconstraints/forbidden_sequence.jl
@@ -102,7 +102,7 @@ function update_rule_indices!(c::ForbiddenSequence, n_rules::Integer)
 end
 
 """
-	update_rule_indices!(c::ForbiddenSequence, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, constraints::Vector{AbstractConstraint})
+	update_rule_indices!(c::ForbiddenSequence, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, constraints::Vector{<:AbstractConstraint})
 
 Updates the rule indices in a `ForbiddenSequence` constraint by applying the given mapping to both the `sequence` and `ignore_if` fields.
 
@@ -112,7 +112,7 @@ Updates the rule indices in a `ForbiddenSequence` constraint by applying the giv
 - `mapping`: Dictionary mapping old rule indices to new rule indices
 - `constraints`: Vector of grammar constraints containing the constraint to update
 """
-function update_rule_indices!(c::ForbiddenSequence, n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer}, constraints::Vector{AbstractConstraint})
+function update_rule_indices!(c::ForbiddenSequence, n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer}, constraints::Vector{<:AbstractConstraint})
     c.sequence .= _get_new_index.(c.sequence, Ref(mapping))
     c.ignore_if .= _get_new_index.(c.ignore_if, Ref(mapping))
     return c

--- a/src/grammarconstraints/forbidden_sequence.jl
+++ b/src/grammarconstraints/forbidden_sequence.jl
@@ -90,30 +90,29 @@ end
 """
 	update_rule_indices!(c::ForbiddenSequence, n_rules::Integer)
 
-Interface function for updating a `ForbiddenSequence` constraint to reflect grammar changes.
+Updates a `ForbiddenSequence` constraint to reflect grammar changes. No operation is performed 
+as `ForbiddenSequence` constraints do not require updates for grammar rule changes.
 
 # Arguments
 - `c`: The `ForbiddenSequence` constraint to be updated.
 - `n_rules`: The new number of rules in the grammar.
-
-# Notes
-This function does not perform any operations because no updates are required for this specific interface.
 """
 function update_rule_indices!(c::ForbiddenSequence, n_rules::Integer)
     # no update required
 end
 
 """
-	update_rule_indices!(c::ForbiddenSequence, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer})
+	update_rule_indices!(c::ForbiddenSequence, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, constraints::Vector{AbstractConstraint})
 
-Updates the rule indices of all fields of a `ForbiddenSequence` constraint based on the given `mapping`.
+Updates the rule indices in a `ForbiddenSequence` constraint by applying the given mapping to both the `sequence` and `ignore_if` fields.
 
 # Arguments
-- `c`: `ForbiddenSequence` constraint.
-- `n_rules`: The new number of rules in the grammar (unused in this implementation).
+- `c`: The `ForbiddenSequence` constraint to be updated
+- `n_rules`: The new number of rules in the grammar  
 - `mapping`: Dictionary mapping old rule indices to new rule indices
+- `constraints`: Vector of grammar constraints containing the constraint to update
 """
-function update_rule_indices!(c::ForbiddenSequence, n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer})
+function update_rule_indices!(c::ForbiddenSequence, n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer}, constraints::Vector{AbstractConstraint})
     c.sequence .= _get_new_index.(c.sequence, Ref(mapping))
     c.ignore_if .= _get_new_index.(c.ignore_if, Ref(mapping))
     return c

--- a/src/grammarconstraints/forbidden_sequence.jl
+++ b/src/grammarconstraints/forbidden_sequence.jl
@@ -94,10 +94,24 @@ Updates a `ForbiddenSequence` constraint to reflect grammar changes. No operatio
 as `ForbiddenSequence` constraints do not require updates for grammar rule changes.
 
 # Arguments
-- `c`: The `ForbiddenSequence` constraint to be updated.
-- `n_rules`: The new number of rules in the grammar.
+- `c`: The `ForbiddenSequence` constraint to be updated
+- `n_rules`: The new number of rules in the grammar
 """
-function update_rule_indices!(c::ForbiddenSequence, n_rules::Integer)
+function HerbCore.update_rule_indices!(c::ForbiddenSequence, n_rules::Integer)
+    # no update required
+end
+
+"""
+	update_rule_indices!(c::ForbiddenSequence, grammar::AbstractGrammar)
+
+Updates a `ForbiddenSequence` constraint to reflect grammar changes. No operation is performed 
+as `ForbiddenSequence` constraints do not require updates for grammar rule changes.
+
+# Arguments
+- `c`: The `ForbiddenSequence` constraint to be updated
+- `grammar`: The grammar that changed
+"""
+function HerbCore.update_rule_indices!(c::ForbiddenSequence, grammar::AbstractGrammar)
     # no update required
 end
 
@@ -112,8 +126,26 @@ Updates the rule indices in a `ForbiddenSequence` constraint by applying the giv
 - `mapping`: Dictionary mapping old rule indices to new rule indices
 - `constraints`: Vector of grammar constraints containing the constraint to update
 """
-function update_rule_indices!(c::ForbiddenSequence, n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer}, constraints::Vector{<:AbstractConstraint})
+function HerbCore.update_rule_indices!(c::ForbiddenSequence, n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer}, constraints::Vector{<:AbstractConstraint})
     c.sequence .= _get_new_index.(c.sequence, Ref(mapping))
     c.ignore_if .= _get_new_index.(c.ignore_if, Ref(mapping))
     return c
+end
+
+"""
+	update_rule_indices!(c::ForbiddenSequence, grammar::AbstractGrammar, mapping::AbstractDict{<:Integer, <:Integer})
+
+Updates the rule indices in a `ForbiddenSequence` constraint by applying the given mapping to both the `sequence` and `ignore_if` fields.
+
+# Arguments
+- `c`: The `ForbiddenSequence` constraint to be updated
+- `grammar`: The grammar that changed
+- `mapping`: Dictionary mapping old rule indices to new rule indices
+"""
+function HerbCore.update_rule_indices!(
+    c::ForbiddenSequence,
+    grammar::AbstractGrammar,
+    mapping::AbstractDict{<:Integer,<:Integer},
+)
+    HerbCore.update_rule_indices!(c, length(grammar.rules), mapping, grammar.constraints)
 end

--- a/src/grammarconstraints/ordered.jl
+++ b/src/grammarconstraints/ordered.jl
@@ -63,24 +63,22 @@ function check_tree(c::Ordered, tree::AbstractRuleNode)::Bool
 end
 
 """
-	update_rule_indices!(c::Ordered, n_rules::Integer)
+    update_rule_indices!(c::Ordered, n_rules::Integer)
 
-Interface function for updating a `Ordered` constraint to reflect grammar changes.
+Updates the `Ordered` constraint to reflect grammar changes. Calls `HerbCore.update_rule_indices!` its `tree` field.
 
 # Arguments
 - `c`: The `Ordered` constraint to be updated.
 - `n_rules`: The new number of rules in the grammar.
 
 # Notes
-This function does not perform any operations because no updates are required for this specific interface.
+This function ensures that every node of the `tree` field of the `Ordered` constraint is updated as required.
 """
 function update_rule_indices!(
     c::Ordered,
     n_rules::Integer,
 )
-    # no update required
-    # HerbCore.update_rule_indices!(c.tree, n_rules) # TODO: check if correct
-
+    HerbCore.update_rule_indices!(c.tree, n_rules)
 end
 
 """

--- a/src/grammarconstraints/ordered.jl
+++ b/src/grammarconstraints/ordered.jl
@@ -82,7 +82,7 @@ function update_rule_indices!(
 end
 
 """
-	update_rule_indices!(c::Ordered, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, constraints::Vector{AbstractConstraint})
+	update_rule_indices!(c::Ordered, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, constraints::Vector{<:AbstractConstraint})
 
 Updates the `Ordered` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
 
@@ -99,7 +99,7 @@ function update_rule_indices!(
     c::Ordered,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
-    constraints::Vector{AbstractConstraint}
+    constraints::Vector{<:AbstractConstraint}
 )
     HerbCore.update_rule_indices!(c.tree, n_rules, mapping)
 end

--- a/src/grammarconstraints/ordered.jl
+++ b/src/grammarconstraints/ordered.jl
@@ -65,7 +65,7 @@ end
 """
     update_rule_indices!(c::Ordered, n_rules::Integer)
 
-Updates the `Ordered` constraint to reflect grammar changes. Calls `HerbCore.update_rule_indices!` its `tree` field.
+Updates the `Ordered` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
 
 # Arguments
 - `c`: The `Ordered` constraint to be updated.
@@ -82,22 +82,24 @@ function update_rule_indices!(
 end
 
 """
-	update_rule_indices!(c::Ordered, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer})
+	update_rule_indices!(c::Ordered, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, constraints::Vector{AbstractConstraint})
 
-Updates the a `Ordered` constraint to reflect grammar changes. Calls `HerbCore.update_rule_indices!` its `tree` field.
+Updates the `Ordered` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
 
 # Arguments
-- `c`: `Ordered` constraint.
-- `n_rules`: The new number of rules in the grammar.
+- `c`: The `Ordered` constraint to be updated
+- `n_rules`: The new number of rules in the grammar  
 - `mapping`: Dictionary mapping old rule indices to new rule indices
+- `constraints`: Vector of grammar constraints containing the constraint to update
 
 # Notes
-This function ensures that every node of the `tree` field of the `Ordered` constraint is updated as required.
+Ensures that every node of the `tree` field is updated as required.
 """
 function update_rule_indices!(
     c::Ordered,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
+    constraints::Vector{AbstractConstraint}
 )
     HerbCore.update_rule_indices!(c.tree, n_rules, mapping)
 end

--- a/src/grammarconstraints/ordered.jl
+++ b/src/grammarconstraints/ordered.jl
@@ -33,8 +33,12 @@ function on_new_node(solver::Solver, c::Ordered, path::Vector{Int})
     #minor optimization: prevent the first hardfail (https://github.com/orgs/Herb-AI/projects/6/views/1?pane=issue&itemId=55570518)
     if c.tree isa RuleNode
         @match get_node_at_location(solver, path) begin
-            hole::AbstractHole => if !hole.domain[c.tree.ind] return end
-            node::RuleNode => if node.ind != c.tree.ind return end
+            hole::AbstractHole => if !hole.domain[c.tree.ind]
+                return
+            end
+            node::RuleNode => if node.ind != c.tree.ind
+                return
+            end
         end
     end
     post!(solver, LocalOrdered(path, c.tree, c.order))
@@ -46,7 +50,7 @@ end
 Checks if the given [`AbstractRuleNode`](@ref) tree abides the [`Ordered`](@ref) constraint.
 """
 function check_tree(c::Ordered, tree::AbstractRuleNode)::Bool
-    vars = Dict{Symbol, AbstractRuleNode}()
+    vars = Dict{Symbol,AbstractRuleNode}()
     if pattern_match(tree, c.tree, vars) isa PatternMatchSuccess
         # Check variable ordering
         for (var₁, var₂) ∈ zip(c.order[1:end-1], c.order[2:end])
@@ -56,4 +60,46 @@ function check_tree(c::Ordered, tree::AbstractRuleNode)::Bool
         end
     end
     return all(check_tree(c, child) for child ∈ tree.children)
+end
+
+"""
+	update_rule_indices!(c::Ordered, n_rules::Integer)
+
+Interface function for updating a `Ordered` constraint to reflect grammar changes.
+
+# Arguments
+- `c`: The `Ordered` constraint to be updated.
+- `n_rules`: The new number of rules in the grammar.
+
+# Notes
+This function does not perform any operations because no updates are required for this specific interface.
+"""
+function update_rule_indices!(
+    c::Ordered,
+    n_rules::Integer,
+)
+    # no update required
+    # HerbCore.update_rule_indices!(c.tree, n_rules) # TODO: check if correct
+
+end
+
+"""
+	update_rule_indices!(c::Ordered, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer})
+
+Updates the a `Ordered` constraint to reflect grammar changes. Calls `HerbCore.update_rule_indices!` its `tree` field.
+
+# Arguments
+- `c`: `Ordered` constraint.
+- `n_rules`: The new number of rules in the grammar.
+- `mapping`: Dictionary mapping old rule indices to new rule indices
+
+# Notes
+This function ensures that every node of the `tree` field of the `Ordered` constraint is updated as required.
+"""
+function update_rule_indices!(
+    c::Ordered,
+    n_rules::Integer,
+    mapping::AbstractDict{<:Integer,<:Integer},
+)
+    HerbCore.update_rule_indices!(c.tree, n_rules, mapping)
 end

--- a/src/grammarconstraints/ordered.jl
+++ b/src/grammarconstraints/ordered.jl
@@ -74,11 +74,30 @@ Updates the `Ordered` constraint to reflect grammar changes by calling `HerbCore
 # Notes
 This function ensures that every node of the `tree` field of the `Ordered` constraint is updated as required.
 """
-function update_rule_indices!(
+function HerbCore.update_rule_indices!(
     c::Ordered,
     n_rules::Integer,
 )
     HerbCore.update_rule_indices!(c.tree, n_rules)
+end
+
+"""
+    update_rule_indices!(c::Ordered, grammar::AbstractGrammar)
+
+Updates the `Ordered` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
+
+# Arguments
+- `c`: The `Ordered` constraint to be updated
+- `grammar`: The grammar that changed
+
+# Notes
+This function ensures that every node of the `tree` field of the `Ordered` constraint is updated as required.
+"""
+function HerbCore.update_rule_indices!(
+    c::Ordered,
+    grammar::AbstractGrammar,
+)
+    HerbCore.update_rule_indices!(c.tree, length(grammar.rules))
 end
 
 """
@@ -95,11 +114,32 @@ Updates the `Ordered` constraint to reflect grammar changes by calling `HerbCore
 # Notes
 Ensures that every node of the `tree` field is updated as required.
 """
-function update_rule_indices!(
+function HerbCore.update_rule_indices!(
     c::Ordered,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
     constraints::Vector{<:AbstractConstraint}
 )
     HerbCore.update_rule_indices!(c.tree, n_rules, mapping)
+end
+
+"""
+	update_rule_indices!(c::Ordered, grammar::AbstractGrammar, mapping::AbstractDict{<:Integer, <:Integer})
+
+Updates the `Ordered` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
+
+# Arguments
+- `c`: The `Ordered` constraint to be updated
+- `grammar`: The grammar that changed
+- `mapping`: Dictionary mapping old rule indices to new rule indices
+
+# Notes
+Ensures that every node of the `tree` field is updated as required.
+"""
+function HerbCore.update_rule_indices!(
+    c::Ordered,
+    grammar::AbstractGrammar,
+    mapping::AbstractDict{<:Integer,<:Integer}
+)
+    HerbCore.update_rule_indices!(c, length(grammar.rules), mapping, grammar.constraints)
 end

--- a/src/grammarconstraints/ordered.jl
+++ b/src/grammarconstraints/ordered.jl
@@ -70,9 +70,6 @@ Updates the `Ordered` constraint to reflect grammar changes by calling `HerbCore
 # Arguments
 - `c`: The `Ordered` constraint to be updated.
 - `n_rules`: The new number of rules in the grammar.
-
-# Notes
-This function ensures that every node of the `tree` field of the `Ordered` constraint is updated as required.
 """
 function HerbCore.update_rule_indices!(
     c::Ordered,
@@ -89,9 +86,6 @@ Updates the `Ordered` constraint to reflect grammar changes by calling `HerbCore
 # Arguments
 - `c`: The `Ordered` constraint to be updated
 - `grammar`: The grammar that changed
-
-# Notes
-This function ensures that every node of the `tree` field of the `Ordered` constraint is updated as required.
 """
 function HerbCore.update_rule_indices!(
     c::Ordered,
@@ -101,7 +95,7 @@ function HerbCore.update_rule_indices!(
 end
 
 """
-	update_rule_indices!(c::Ordered, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, constraints::Vector{<:AbstractConstraint})
+	update_rule_indices!(c::Ordered, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer}, ::Vector{<:AbstractConstraint})
 
 Updates the `Ordered` constraint to reflect grammar changes by calling `HerbCore.update_rule_indices!` on its `tree` field.
 
@@ -109,16 +103,12 @@ Updates the `Ordered` constraint to reflect grammar changes by calling `HerbCore
 - `c`: The `Ordered` constraint to be updated
 - `n_rules`: The new number of rules in the grammar  
 - `mapping`: Dictionary mapping old rule indices to new rule indices
-- `constraints`: Vector of grammar constraints containing the constraint to update
-
-# Notes
-Ensures that every node of the `tree` field is updated as required.
 """
 function HerbCore.update_rule_indices!(
     c::Ordered,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
-    constraints::Vector{<:AbstractConstraint}
+    ::Vector{<:AbstractConstraint}
 )
     HerbCore.update_rule_indices!(c.tree, n_rules, mapping)
 end
@@ -132,9 +122,6 @@ Updates the `Ordered` constraint to reflect grammar changes by calling `HerbCore
 - `c`: The `Ordered` constraint to be updated
 - `grammar`: The grammar that changed
 - `mapping`: Dictionary mapping old rule indices to new rule indices
-
-# Notes
-Ensures that every node of the `tree` field is updated as required.
 """
 function HerbCore.update_rule_indices!(
     c::Ordered,

--- a/src/grammarconstraints/unique.jl
+++ b/src/grammarconstraints/unique.jl
@@ -58,7 +58,7 @@ end
     HerbCore.update_rule_indices!(c::Unique,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
-    constraints::Vector{AbstractConstraint})
+    constraints::Vector{<:AbstractConstraint})
 
 Updates the `Unique` constraint to reflect grammar changes by replacing it with a new 
 `Unique` constraint using the mapped rule index.
@@ -72,8 +72,8 @@ Updates the `Unique` constraint to reflect grammar changes by replacing it with 
 function update_rule_indices!(c::Unique,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
-    constraints::Vector{AbstractConstraint})
-    index = findfirst(x -> x == c, c_vector) # assumes no duplicate constraints => TODO: can we assume this?
+    constraints::Vector{<:AbstractConstraint})
+    index = findfirst(x -> x == c, constraints) # assumes no duplicate constraints => TODO: can we assume this?
     new_rule = _get_new_index(c.rule, mapping)
-    c_vector[index] = Unique(new_rule)
+    constraints[index] = Unique(new_rule)
 end

--- a/src/grammarconstraints/unique.jl
+++ b/src/grammarconstraints/unique.jl
@@ -39,3 +39,41 @@ Checks if the given [`AbstractRuleNode`](@ref) tree abides the [`Unique`](@ref) 
 function check_tree(c::Unique, tree::AbstractRuleNode)::Bool
     return _count_occurrences(tree, c.rule) <= 1
 end
+
+"""
+	update_rule_indices!(c::Unique, n_rules::Integer)
+
+Updates a `Unique` constraint to reflect grammar changes. No operation is performed 
+as `Unique` constraints do not require updates for grammar rule changes.
+
+# Arguments
+- `c`: The `Unique` constraint to be updated.
+- `n_rules`: The new number of rules in the grammar.
+"""
+function update_rule_indices!(c::Unique, n_rules::Integer)
+    # no update required
+end
+
+"""
+    HerbCore.update_rule_indices!(c::Unique,
+    n_rules::Integer,
+    mapping::AbstractDict{<:Integer,<:Integer},
+    constraints::Vector{AbstractConstraint})
+
+Updates the `Unique` constraint to reflect grammar changes by replacing it with a new 
+`Unique` constraint using the mapped rule index.
+
+# Arguments
+- `c`: The `Unique` constraint to be updated
+- `n_rules`: The new number of rules in the grammar  
+- `mapping`: Dictionary mapping old rule indices to new rule indices
+- `constraints`: Vector of grammar constraints containing the constraint to update
+"""
+function update_rule_indices!(c::Unique,
+    n_rules::Integer,
+    mapping::AbstractDict{<:Integer,<:Integer},
+    constraints::Vector{AbstractConstraint})
+    index = findfirst(x -> x == c, c_vector) # assumes no duplicate constraints => TODO: can we assume this?
+    new_rule = _get_new_index(c.rule, mapping)
+    c_vector[index] = Unique(new_rule)
+end

--- a/src/grammarconstraints/unique.jl
+++ b/src/grammarconstraints/unique.jl
@@ -50,7 +50,21 @@ as `Unique` constraints do not require updates for grammar rule changes.
 - `c`: The `Unique` constraint to be updated.
 - `n_rules`: The new number of rules in the grammar.
 """
-function update_rule_indices!(c::Unique, n_rules::Integer)
+function HerbCore.update_rule_indices!(c::Unique, n_rules::Integer)
+    # no update required
+end
+
+"""
+	update_rule_indices!(c::Unique, grammar::AbstractGrammar)
+
+Updates a `Unique` constraint to reflect grammar changes. No operation is performed 
+as `Unique` constraints do not require updates for grammar rule changes.
+
+# Arguments
+- `c`: The `Unique` constraint to be updated
+- `grammar`: The grammar that changed
+"""
+function HerbCore.update_rule_indices!(c::Unique, grammar::AbstractGrammar)
     # no update required
 end
 
@@ -69,11 +83,30 @@ Updates the `Unique` constraint to reflect grammar changes by replacing it with 
 - `mapping`: Dictionary mapping old rule indices to new rule indices
 - `constraints`: Vector of grammar constraints containing the constraint to update
 """
-function update_rule_indices!(c::Unique,
+function HerbCore.update_rule_indices!(c::Unique,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
     constraints::Vector{<:AbstractConstraint})
     index = findfirst(x -> x == c, constraints) # assumes no duplicate constraints => TODO: can we assume this?
     new_rule = _get_new_index(c.rule, mapping)
     constraints[index] = Unique(new_rule)
+end
+
+"""
+    HerbCore.update_rule_indices!(c::Unique,
+    grammar::AbstractGrammar,
+    mapping::AbstractDict{<:Integer,<:Integer})
+
+Updates the `Unique` constraint to reflect grammar changes by replacing it with a new 
+`Unique` constraint using the mapped rule index.
+
+# Arguments
+- `c`: The `Unique` constraint to be updated
+- `grammar`: The grammar that changed
+- `mapping`: Dictionary mapping old rule indices to new rule indices
+"""
+function HerbCore.update_rule_indices!(c::Unique,
+    grammar::AbstractGrammar,
+    mapping::AbstractDict{<:Integer,<:Integer})
+    HerbCore.update_rule_indices!(c, length(grammar.rules), mapping, grammar.constraints)
 end

--- a/src/grammarconstraints/unique.jl
+++ b/src/grammarconstraints/unique.jl
@@ -43,28 +43,30 @@ end
 """
 	update_rule_indices!(c::Unique, n_rules::Integer)
 
-Updates a `Unique` constraint to reflect grammar changes. No operation is performed 
-as `Unique` constraints do not require updates for grammar rule changes.
+Updates a `Unique` constraint to reflect grammar changes. Errors if rule index exceeds new `n_rules`.
 
 # Arguments
 - `c`: The `Unique` constraint to be updated.
 - `n_rules`: The new number of rules in the grammar.
 """
 function HerbCore.update_rule_indices!(c::Unique, n_rules::Integer)
+    if c.rule > n_rules
+        error("Rule index $(c.rule) exceeds the number of grammar rules ($n_rules).")
+    end
     # no update required
 end
 
 """
 	update_rule_indices!(c::Unique, grammar::AbstractGrammar)
 
-Updates a `Unique` constraint to reflect grammar changes. No operation is performed 
-as `Unique` constraints do not require updates for grammar rule changes.
+Updates a `Unique` constraint to reflect grammar changes. Errors if rule index exceeds number of grammar rules.
 
 # Arguments
 - `c`: The `Unique` constraint to be updated
 - `grammar`: The grammar that changed
 """
 function HerbCore.update_rule_indices!(c::Unique, grammar::AbstractGrammar)
+    HerbCore.update_rule_indices!(c, length(grammar.rules))
     # no update required
 end
 
@@ -75,7 +77,7 @@ end
     constraints::Vector{<:AbstractConstraint})
 
 Updates the `Unique` constraint to reflect grammar changes by replacing it with a new 
-`Unique` constraint using the mapped rule index.
+`Unique` constraint using the mapped rule index. Errors if rule index exceeds new `n_rules`.
 
 # Arguments
 - `c`: The `Unique` constraint to be updated
@@ -87,8 +89,11 @@ function HerbCore.update_rule_indices!(c::Unique,
     n_rules::Integer,
     mapping::AbstractDict{<:Integer,<:Integer},
     constraints::Vector{<:AbstractConstraint})
-    index = findfirst(x -> x == c, constraints) # assumes no duplicate constraints => TODO: can we assume this?
-    new_rule = _get_new_index(c.rule, mapping)
+    if c.rule > n_rules
+        error("Rule index $(c.rule) exceeds the number of grammar rules ($n_rules).")
+    end
+    index = only(findall(x -> x == c, constraints))
+    new_rule = new_rule = get(mapping, c.rule, c.rule) # keep rule index if no matching entry found in mapping
     constraints[index] = Unique(new_rule)
 end
 
@@ -98,7 +103,7 @@ end
     mapping::AbstractDict{<:Integer,<:Integer})
 
 Updates the `Unique` constraint to reflect grammar changes by replacing it with a new 
-`Unique` constraint using the mapped rule index.
+`Unique` constraint using the mapped rule index.Errors if rule index exceeds number of grammar rules.
 
 # Arguments
 - `c`: The `Unique` constraint to be updated

--- a/src/grammarconstraints/utils.jl
+++ b/src/grammarconstraints/utils.jl
@@ -2,6 +2,6 @@
 	Returns the new index of a grammar rule bsed on the provided `mapping`.
 	If `rule` is NOT a key in `mapping`, the original `rule` is returned.
 """
-function _get_new_index(rule::Int, mapping::AbstractDict{<:Integer, <:Integer})
+function _get_new_index(rule::Int, mapping::AbstractDict{<:Integer,<:Integer})
     get(mapping, rule, rule)
 end # TODO: do we need this function?

--- a/src/grammarconstraints/utils.jl
+++ b/src/grammarconstraints/utils.jl
@@ -1,0 +1,7 @@
+"""
+	Returns the new index of a grammar rule bsed on the provided `mapping`.
+	If `rule` is NOT a key in `mapping`, the original `rule` is returned.
+"""
+function _get_new_index(rule::Int, mapping::AbstractDict{<:Integer, <:Integer})
+    get(mapping, rule, rule)
+end # TODO: do we need this function?

--- a/src/grammarconstraints/utils.jl
+++ b/src/grammarconstraints/utils.jl
@@ -1,7 +1,0 @@
-"""
-	Returns the new index of a grammar rule bsed on the provided `mapping`.
-	If `rule` is NOT a key in `mapping`, the original `rule` is returned.
-"""
-function _get_new_index(rule::Int, mapping::AbstractDict{<:Integer,<:Integer})
-    get(mapping, rule, rule)
-end # TODO: do we need this function?

--- a/src/varnode.jl
+++ b/src/varnode.jl
@@ -32,3 +32,32 @@ Checks if an [`AbstractRuleNode`](@ref) tree contains a [`VarNode`](@ref) with t
 """
 contains_varnode(rn::AbstractRuleNode, name::Symbol) = any(contains_varnode(c, name) for c ∈ rn.children)
 contains_varnode(vn::VarNode, name::Symbol) = vn.name == name
+
+"""
+	HerbCore.update_rule_indices!(c::ContainVarNodesSubtree, n_rules::Integer)
+
+This function serves as interface for `HerbCore.update_rule_indices!` on node type `VarNode`. Since `VarNode` doesn't change,
+this function does not perform any operations. 
+
+"""
+function HerbCore.update_rule_indices!(
+    node::VarNode,
+    n_rules::Integer,
+)
+    # VarNode does not change
+end
+
+"""
+	HerbCore.update_rule_indices!(c::VarNode, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer})
+
+This function serves as interface for `HerbCore.update_rule_indices!` on node type `VarNode`. Since `VarNode` doesn't change,
+this function does not perform any operations. 
+
+"""
+function HerbCore.update_rule_indices!(
+    node::VarNode,
+    n_rules::Integer,
+    mapping::AbstractDict{<:Integer,<:Integer},
+)
+    # VarNode does not change
+end

--- a/src/varnode.jl
+++ b/src/varnode.jl
@@ -34,11 +34,9 @@ contains_varnode(rn::AbstractRuleNode, name::Symbol) = any(contains_varnode(c, n
 contains_varnode(vn::VarNode, name::Symbol) = vn.name == name
 
 """
-	HerbCore.update_rule_indices!(c::ContainVarNodesSubtree, n_rules::Integer)
+     HerbCore.update_rule_indices!(c::ContainVarNodesSubtree, n_rules::Integer)
 
-This function serves as interface for `HerbCore.update_rule_indices!` on node type `VarNode`. Since `VarNode` doesn't change,
-this function does not perform any operations. 
-
+Update the rule indices of a `VarNode`. As `VarNode`s contain no indices, this function does nothing.
 """
 function HerbCore.update_rule_indices!(
     node::VarNode,

--- a/src/varnode.jl
+++ b/src/varnode.jl
@@ -39,8 +39,8 @@ contains_varnode(vn::VarNode, name::Symbol) = vn.name == name
 Update the rule indices of a `VarNode`. As `VarNode`s contain no indices, this function does nothing.
 """
 function HerbCore.update_rule_indices!(
-    node::VarNode,
-    n_rules::Integer,
+    ::VarNode,
+    ::Integer,
 )
     # VarNode does not change
 end
@@ -48,14 +48,12 @@ end
 """
 	HerbCore.update_rule_indices!(c::VarNode, n_rules::Integer, mapping::AbstractDict{<:Integer, <:Integer})
 
-This function serves as interface for `HerbCore.update_rule_indices!` on node type `VarNode`. Since `VarNode` doesn't change,
-this function does not perform any operations. 
-
+Update the rule indices of a `VarNode`. As `VarNode`s contain no indices, this function does nothing.
 """
 function HerbCore.update_rule_indices!(
-    node::VarNode,
-    n_rules::Integer,
-    mapping::AbstractDict{<:Integer,<:Integer},
+    ::VarNode,
+    ::Integer,
+    ::AbstractDict{<:Integer,<:Integer},
 )
     # VarNode does not change
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,4 +25,5 @@ using Test
 
     include("test_state_fixed_shaped_hole.jl")
     include("test_domainrulenode.jl")
+    include("test_grammarconstraints.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,15 @@
-using HerbCore 
+using HerbCore
 using HerbConstraints
+using HerbGrammar
 using Test
 
-@testset "HerbConstraints.jl" verbose=true begin
+@testset "HerbConstraints.jl" verbose = true begin
     include("test_domain_utils.jl")
     include("test_treemanipulations.jl")
     include("test_varnode.jl")
     include("test_pattern_match.jl")
     include("test_pattern_match_domainrulenode.jl")
-    #include("test_pattern_match_edgecases.jl")
+    # include("test_pattern_match_edgecases.jl")
     include("test_lessthanorequal.jl")
     include("test_makeequal.jl")
     include("test_forbidden.jl")
@@ -23,4 +24,5 @@ using Test
     include("test_state_manager.jl")
 
     include("test_state_fixed_shaped_hole.jl")
+    include("test_domainrulenode.jl")
 end

--- a/test/test_contains.jl
+++ b/test/test_contains.jl
@@ -43,13 +43,13 @@
             addconstraint!(grammar, Contains(3))
             n_rules = 5
             HerbCore.update_rule_indices!(c, n_rules)
-            @test grammar.constraints[1] == Contains(2)
+            @test Contains(2) in grammar.constraints
             mapping = Dict(1 => 5, 2 => 6)
             HerbCore.update_rule_indices!(c, n_rules,
                 mapping, grammar.constraints)
-            @test grammar.constraints[1] == Contains(6)
+            @test Contains(6) in grammar.constraints
+            @test !(Contains(2) in grammar.constraints)
         end
-        # TODO: interface with grammar
 
         @testset "interface with grammar" begin
             clearconstraints!(grammar)
@@ -59,7 +59,13 @@
             @test grammar.constraints[1] == Contains(2)
             mapping = Dict(1 => 5, 2 => 6)
             HerbCore.update_rule_indices!(c, grammar, mapping)
-            @test grammar.constraints[1] == Contains(6)
+            @test Contains(6) in grammar.constraints
+        end
+        @testset "error" begin
+            clearconstraints!(grammar)
+            c = Contains(23)
+            addconstraint!(grammar, c)
+            @test_throws ErrorException HerbCore.update_rule_indices!(c, grammar)
         end
     end
 end

--- a/test/test_contains.jl
+++ b/test/test_contains.jl
@@ -37,13 +37,29 @@
             Int = Int + Int
             Int = Int * Int
         end
-        addconstraint!(grammar, Contains(2))
-        addconstraint!(grammar, Contains(3))
         c = Contains(2)
-        n_rules = 5
-        mapping = Dict(1 => 5, 2 => 6)
-        HerbConstraints.update_rule_indices!(c, n_rules,
-            mapping, grammar.constraints)
-        @test grammar.constraints[1] == Contains(6)
+        @testset "interface without grammar" begin
+            addconstraint!(grammar, Contains(2))
+            addconstraint!(grammar, Contains(3))
+            n_rules = 5
+            HerbCore.update_rule_indices!(c, n_rules)
+            @test grammar.constraints[1] == Contains(2)
+            mapping = Dict(1 => 5, 2 => 6)
+            HerbCore.update_rule_indices!(c, n_rules,
+                mapping, grammar.constraints)
+            @test grammar.constraints[1] == Contains(6)
+        end
+        # TODO: interface with grammar
+
+        @testset "interface with grammar" begin
+            clearconstraints!(grammar)
+            addconstraint!(grammar, Contains(2))
+            addconstraint!(grammar, Contains(3))
+            HerbCore.update_rule_indices!(c, grammar)
+            @test grammar.constraints[1] == Contains(2)
+            mapping = Dict(1 => 5, 2 => 6)
+            HerbCore.update_rule_indices!(c, grammar, mapping)
+            @test grammar.constraints[1] == Contains(6)
+        end
     end
 end

--- a/test/test_contains.jl
+++ b/test/test_contains.jl
@@ -1,4 +1,4 @@
-@testset verbose=false "Contains" begin
+@testset verbose = false "Contains" begin
     contains = Contains(2)
 
     @testset "check_tree true" begin
@@ -27,5 +27,24 @@
 
         @test check_tree(contains, tree1) == false
         @test check_tree(contains, tree2) == false
+    end
+
+    @testset "update_rule_indices!" begin
+        grammar = @csgrammar begin
+            Int = 1
+            Int = x
+            Int = -Int
+            Int = Int + Int
+            Int = Int * Int
+        end
+        addconstraint!(grammar, Contains(2))
+        addconstraint!(grammar, Contains(3))
+        c = Contains(2)
+        n_rules = 5
+        mapping = Dict(1 => 5, 2 => 6)
+        HerbConstraints.update_rule_indices!(c, grammar.constraints,
+            n_rules,
+            mapping)
+        @test grammar.constraints[1] == Contains(6)
     end
 end

--- a/test/test_contains.jl
+++ b/test/test_contains.jl
@@ -42,9 +42,8 @@
         c = Contains(2)
         n_rules = 5
         mapping = Dict(1 => 5, 2 => 6)
-        HerbConstraints.update_rule_indices!(c, grammar.constraints,
-            n_rules,
-            mapping)
+        HerbConstraints.update_rule_indices!(c, n_rules,
+            mapping, grammar.constraints)
         @test grammar.constraints[1] == Contains(6)
     end
 end

--- a/test/test_contains_subtree.jl
+++ b/test/test_contains_subtree.jl
@@ -315,7 +315,8 @@
             @test check_tree(contains_subtree, tree) == false
 
             mapping = Dict(1 => 7, 5 => 3)
-            HerbConstraints.update_rule_indices!(contains_subtree, n_rules, mapping)
+            constraints = [contains_subtree]
+            HerbConstraints.update_rule_indices!(contains_subtree, n_rules, mapping, constraints)
             @test check_tree(contains_subtree, tree) == true
             @test contains_subtree.tree == expected_contains_subtree.tree
         end

--- a/test/test_contains_subtree.jl
+++ b/test/test_contains_subtree.jl
@@ -294,16 +294,6 @@
     end
     @testset verbose = true "Update rule indices" begin
         @testset "Update rule index only." begin
-            # with mapping
-
-            n_rules = 10
-            contains_subtree = ContainsSubtree(
-                RuleNode(5, [
-                    VarNode(:a),
-                    VarNode(:a),
-                ]),
-            )
-
             expected_contains_subtree = ContainsSubtree(
                 RuleNode(3, [
                     VarNode(:a),
@@ -311,14 +301,45 @@
                 ]),
             )
             tree = @rulenode 3{3{1,1},2}
-            HerbConstraints.update_rule_indices!(contains_subtree, n_rules) # no change to RuleNode and VarNode
-            @test check_tree(contains_subtree, tree) == false
-
             mapping = Dict(1 => 7, 5 => 3)
-            constraints = [contains_subtree]
-            HerbConstraints.update_rule_indices!(contains_subtree, n_rules, mapping, constraints)
-            @test check_tree(contains_subtree, tree) == true
-            @test contains_subtree.tree == expected_contains_subtree.tree
+            @testset "interface without grammar" begin
+                n_rules = 5
+                contains_subtree = ContainsSubtree(
+                    RuleNode(5, [
+                        VarNode(:a),
+                        VarNode(:a),
+                    ]),
+                )
+                HerbCore.update_rule_indices!(contains_subtree, n_rules) # no change to RuleNode and VarNode
+                @test check_tree(contains_subtree, tree) == false
+                # with mapping
+                constraints = [contains_subtree]
+                HerbCore.update_rule_indices!(contains_subtree, n_rules, mapping, constraints)
+                @test check_tree(contains_subtree, tree) == true
+                @test contains_subtree.tree == expected_contains_subtree.tree
+            end
+            @testset "interface with grammar" begin
+                grammar = @csgrammar begin
+                    Int = 1
+                    Int = x
+                    Int = -Int
+                    Int = Int + Int
+                    Int = Int * Int
+                end
+                contains_subtree = ContainsSubtree(
+                    RuleNode(5, [
+                        VarNode(:a),
+                        VarNode(:a),
+                    ]),
+                )
+                HerbCore.update_rule_indices!(contains_subtree, grammar)
+                @test check_tree(contains_subtree, tree) == false
+                # with mapping
+                HerbCore.update_rule_indices!(contains_subtree, grammar, mapping)
+                @test check_tree(contains_subtree, tree) == true
+                @test contains_subtree.tree == expected_contains_subtree.tree
+            end
         end
+
     end
 end

--- a/test/test_domainrulenode.jl
+++ b/test/test_domainrulenode.jl
@@ -1,0 +1,30 @@
+@testset verbose = true "DomainRuleNode" begin
+    @testset "Update domain size only" begin
+        node = DomainRuleNode(BitVector((1, 0)))
+        n_rules = 5
+        HerbCore.update_rule_indices!(node, n_rules)
+        @test node.domain == BitVector((1, 0, 0, 0, 0))
+    end
+    @testset "Update domain size and remap indices" begin
+        node = DomainRuleNode(BitVector((1, 0, 1)))
+        n_rules = 10
+        mapping = Dict(1 => 4, 3 => 6, 4 => 7)
+        HerbCore.update_rule_indices!(node, n_rules, mapping)
+        expected_domain = BitVector(zeros(n_rules))
+        expected_domain[[4, 6...]] .= true
+        @test node.domain == expected_domain
+    end
+
+    # TODO: test with children 
+    @testset "with children" begin
+        node = DomainRuleNode(BitVector((1, 0)), [DomainRuleNode(BitVector((1, 1))), DomainRuleNode(BitVector((0, 1)))])
+        n_rules = 4
+        mapping = Dict(1 => 3, 2 => 4)
+        HerbCore.update_rule_indices!(node, n_rules, mapping)
+        @test node.domain == BitVector((0, 0, 1, 0))
+        children = get_children(node)
+        @test length(children) == 2
+        @test children[1].domain == BitVector((0, 0, 1, 1))
+        @test children[2].domain == BitVector((0, 0, 0, 1))
+    end
+end

--- a/test/test_domainrulenode.jl
+++ b/test/test_domainrulenode.jl
@@ -14,9 +14,7 @@
         expected_domain[[4, 6...]] .= true
         @test node.domain == expected_domain
     end
-
-    # TODO: test with children 
-    @testset "with children" begin
+    @testset "Update with children" begin
         node = DomainRuleNode(BitVector((1, 0)), [DomainRuleNode(BitVector((1, 1))), DomainRuleNode(BitVector((0, 1)))])
         n_rules = 4
         mapping = Dict(1 => 3, 2 => 4)
@@ -26,5 +24,10 @@
         @test length(children) == 2
         @test children[1].domain == BitVector((0, 0, 1, 1))
         @test children[2].domain == BitVector((0, 0, 0, 1))
+    end
+    @testset "error" begin
+        node = DomainRuleNode(BitVector((1, 0, 0, 0, 0)), [DomainRuleNode(BitVector((1, 1))), DomainRuleNode(BitVector((0, 1)))])
+        n_rules = 3
+        @test_throws ErrorException HerbCore.update_rule_indices!(node, n_rules)
     end
 end

--- a/test/test_forbidden.jl
+++ b/test/test_forbidden.jl
@@ -71,9 +71,10 @@
         ])
 
         mapping = Dict(3 => 9, 2 => 22)
+        constraints = [forbidden]
         expected_forbidden = Forbidden(RuleNode(9, [VarNode(:a), VarNode(:a)
         ]))
-        HerbConstraints.update_rule_indices!(forbidden, n_rules, mapping)
+        HerbConstraints.update_rule_indices!(forbidden, n_rules, mapping, constraints)
         @test check_tree(forbidden, tree) == true
         @test forbidden.tree == expected_forbidden.tree
     end

--- a/test/test_forbidden.jl
+++ b/test/test_forbidden.jl
@@ -1,4 +1,4 @@
-@testset verbose=false "Forbidden" begin
+@testset verbose = false "Forbidden" begin
     forbidden = Forbidden(RuleNode(4, [
         VarNode(:a),
         VarNode(:a)
@@ -58,5 +58,23 @@
         ])
         @test check_tree(forbidden, tree22) == false
         @test check_tree(forbidden, tree_large_false) == false
+    end
+
+    @testset "update_rule_indices" begin
+        forbidden = Forbidden(RuleNode(3, [VarNode(:a), VarNode(:a)
+        ]))
+        tree = @rulenode 3{4{2,3{2,2}},7}
+        n_rules = 5
+        HerbConstraints.update_rule_indices!(forbidden, n_rules)
+        @test check_tree(forbidden, tree) == false
+        @test forbidden.tree == RuleNode(3, [VarNode(:a), VarNode(:a)
+        ])
+
+        mapping = Dict(3 => 9, 2 => 22)
+        expected_forbidden = Forbidden(RuleNode(9, [VarNode(:a), VarNode(:a)
+        ]))
+        HerbConstraints.update_rule_indices!(forbidden, n_rules, mapping)
+        @test check_tree(forbidden, tree) == true
+        @test forbidden.tree == expected_forbidden.tree
     end
 end

--- a/test/test_forbidden.jl
+++ b/test/test_forbidden.jl
@@ -61,21 +61,45 @@
     end
 
     @testset "update_rule_indices" begin
-        forbidden = Forbidden(RuleNode(3, [VarNode(:a), VarNode(:a)
-        ]))
-        tree = @rulenode 3{4{2,3{2,2}},7}
-        n_rules = 5
-        HerbConstraints.update_rule_indices!(forbidden, n_rules)
-        @test check_tree(forbidden, tree) == false
-        @test forbidden.tree == RuleNode(3, [VarNode(:a), VarNode(:a)
-        ])
+        @testset "interface without grammar" begin
+            forbidden = Forbidden(RuleNode(3, [VarNode(:a), VarNode(:a)
+            ]))
+            tree = @rulenode 3{4{2,3{2,2}},7}
+            n_rules = 5
+            HerbCore.update_rule_indices!(forbidden, n_rules)
+            @test check_tree(forbidden, tree) == false
+            @test forbidden.tree == RuleNode(3, [VarNode(:a), VarNode(:a)
+            ])
 
-        mapping = Dict(3 => 9, 2 => 22)
-        constraints = [forbidden]
-        expected_forbidden = Forbidden(RuleNode(9, [VarNode(:a), VarNode(:a)
-        ]))
-        HerbConstraints.update_rule_indices!(forbidden, n_rules, mapping, constraints)
-        @test check_tree(forbidden, tree) == true
-        @test forbidden.tree == expected_forbidden.tree
+            mapping = Dict(3 => 9, 2 => 22)
+            constraints = [forbidden]
+            expected_forbidden = Forbidden(RuleNode(9, [VarNode(:a), VarNode(:a)
+            ]))
+            HerbCore.update_rule_indices!(forbidden, n_rules, mapping, constraints)
+            @test check_tree(forbidden, tree) == true
+            @test forbidden.tree == expected_forbidden.tree
+        end
+        @testset "interface with grammar" begin
+            grammar = @csgrammar begin
+                Int = |(1:9)
+                Int = x
+                Int = -Int
+                Int = Int + Int
+                Int = Int * Int
+            end
+            forbidden = Forbidden(RuleNode(3, [VarNode(:a), VarNode(:a)]))
+            addconstraint!(grammar, forbidden)
+            tree = @rulenode 3{4{2,3{2,2}},7}
+            HerbCore.update_rule_indices!(forbidden, grammar)
+            @test check_tree(forbidden, tree) == false
+            @test forbidden.tree == RuleNode(3, [VarNode(:a), VarNode(:a)])
+
+            mapping = Dict(3 => 9, 2 => 22)
+            expected_forbidden = Forbidden(RuleNode(9, [VarNode(:a), VarNode(:a)
+            ]))
+            HerbCore.update_rule_indices!(forbidden, grammar, mapping)
+            @test check_tree(forbidden, tree) == true
+            @test forbidden.tree == expected_forbidden.tree
+        end
     end
 end

--- a/test/test_forbidden_sequence.jl
+++ b/test/test_forbidden_sequence.jl
@@ -327,5 +327,17 @@
             @test grammar.constraints[1].sequence == [10, 2, 99]
             @test grammar.constraints[1].ignore_if == [2, 6]
         end
+        @testset "error" begin
+            grammar = @csgrammar begin
+                Int = 1
+                Int = x
+                Int = -Int
+                Int = Int + Int
+                Int = Int * Int
+            end
+            c = ForbiddenSequence([1, 2, 10], [2, 5])
+            addconstraint!(grammar, c)
+            @test_throws ErrorException HerbCore.update_rule_indices!(c, grammar)
+        end
     end
 end

--- a/test/test_forbidden_sequence.jl
+++ b/test/test_forbidden_sequence.jl
@@ -297,15 +297,35 @@
     end
 
     @testset "update_rule_indices!" begin
-        c = ForbiddenSequence([1, 2, 3], [2, 5])
-        n_rules = 10
-        HerbConstraints.update_rule_indices!(c, n_rules)
-        @test c.sequence == [1, 2, 3]
-        @test c.ignore_if == [2, 5]
-        mapping = Dict(1 => 10, 3 => 99, 5 => 6)
-        constraints = [c]
-        HerbConstraints.update_rule_indices!(c, n_rules, mapping, constraints)
-        @test c.sequence == [10, 2, 99]
-        @test c.ignore_if == [2, 6]
+        @testset "interface without grammar" begin
+            c = ForbiddenSequence([1, 2, 3], [2, 5])
+            n_rules = 10
+            HerbCore.update_rule_indices!(c, n_rules)
+            @test c.sequence == [1, 2, 3]
+            @test c.ignore_if == [2, 5]
+            mapping = Dict(1 => 10, 3 => 99, 5 => 6)
+            constraints = [c]
+            HerbCore.update_rule_indices!(c, n_rules, mapping, constraints)
+            @test c.sequence == [10, 2, 99]
+            @test c.ignore_if == [2, 6]
+        end
+        @testset "interface with grammar" begin
+            grammar = @csgrammar begin
+                Int = 1
+                Int = x
+                Int = -Int
+                Int = Int + Int
+                Int = Int * Int
+            end
+            c = ForbiddenSequence([1, 2, 3], [2, 5])
+            addconstraint!(grammar, c)
+            HerbCore.update_rule_indices!(c, grammar)
+            @test grammar.constraints[1].sequence == [1, 2, 3]
+            @test grammar.constraints[1].ignore_if == [2, 5]
+            mapping = Dict(1 => 10, 3 => 99, 5 => 6)
+            HerbCore.update_rule_indices!(c, grammar, mapping)
+            @test grammar.constraints[1].sequence == [10, 2, 99]
+            @test grammar.constraints[1].ignore_if == [2, 6]
+        end
     end
 end

--- a/test/test_forbidden_sequence.jl
+++ b/test/test_forbidden_sequence.jl
@@ -297,14 +297,15 @@
     end
 
     @testset "update_rule_indices!" begin
-        constraint = ForbiddenSequence([1, 2, 3], [2, 5])
+        c = ForbiddenSequence([1, 2, 3], [2, 5])
         n_rules = 10
-        HerbConstraints.update_rule_indices!(constraint, n_rules)
-        @test constraint.sequence == [1, 2, 3]
-        @test constraint.ignore_if == [2, 5]
+        HerbConstraints.update_rule_indices!(c, n_rules)
+        @test c.sequence == [1, 2, 3]
+        @test c.ignore_if == [2, 5]
         mapping = Dict(1 => 10, 3 => 99, 5 => 6)
-        HerbConstraints.update_rule_indices!(constraint, n_rules, mapping)
-        @test constraint.sequence == [10, 2, 99]
-        @test constraint.ignore_if == [2, 6]
+        constraints = [c]
+        HerbConstraints.update_rule_indices!(c, n_rules, mapping, constraints)
+        @test c.sequence == [10, 2, 99]
+        @test c.ignore_if == [2, 6]
     end
 end

--- a/test/test_forbidden_sequence.jl
+++ b/test/test_forbidden_sequence.jl
@@ -1,4 +1,4 @@
-@testset verbose=false "Forbidden Sequence" begin
+@testset verbose = false "Forbidden Sequence" begin
     function dummy_tree(sequence)::AbstractRuleNode
         # returns a tree that contains the specified sequence and some noise.
         # holes can be represented by tuples of indices
@@ -16,18 +16,18 @@
         end
         return RuleNode(sequence[1], children)
     end
-    
+
     function dummy_solver(sequence, constraint)::Solver
         grammar = @csgrammar begin
             S = (S, 1) | (S, 2) | (S, 3) | (S, 4) | (S, 5) | (S, 6) | (S, 7) | (S, 8)
             S = 9
         end
         # only 1 grammar is ever instantiated (at compile time), so we need to clear the grammar
-        empty!(grammar.constraints) 
+        empty!(grammar.constraints)
         addconstraint!(grammar, constraint)
         return GenericSolver(grammar, dummy_tree(sequence))
     end
-    
+
     function get_sequence(solver, n)
         #converts a tree into a sequence of Int (representing a rule) and Tuple{Int} (representing a domain of rules)
         sequence = []
@@ -44,10 +44,10 @@
         end
         return sequence
     end
-    
+
     function test_propagation(
-        constraint::ForbiddenSequence, 
-        sequence_before_propagation, 
+        constraint::ForbiddenSequence,
+        sequence_before_propagation,
         sequence_after_propagation
     )
         # An "Int" in the sequence represents a rule (RuleNode)
@@ -57,9 +57,9 @@
         expected = sequence_after_propagation
         @test actual == expected
     end
-    
+
     function test_infeasible(
-        constraint::ForbiddenSequence, 
+        constraint::ForbiddenSequence,
         sequence_before_propagation
     )
         solver = dummy_solver(sequence_before_propagation, constraint)
@@ -88,7 +88,7 @@
             tree4 = dummy_tree([1, 2, 1, 2, 3])
             tree5 = dummy_tree([3, 2, 1, 1, 2, 3])
             tree6 = dummy_tree([1, 1, 2, 2, 3, 3])
-            
+
             @test check_tree(constraint, tree1) == false
             @test check_tree(constraint, tree2) == false
             @test check_tree(constraint, tree3) == false
@@ -102,7 +102,7 @@
 
             tree1 = dummy_tree([1, 2, 5, 3])
             tree2 = dummy_tree([5, 1, 5, 2, 5, 3, 1])
-            
+
             @test check_tree(constraint, tree1) == true
             @test check_tree(constraint, tree2) == true
         end
@@ -117,7 +117,7 @@
             tree5 = dummy_tree([1, 2, 5, 1, 2, 3])
             tree6 = dummy_tree([1, 2, 3, 5, 3])
             tree7 = dummy_tree([1, 5, 1, 2, 3])
-            
+
             @test check_tree(constraint, tree1) == false
             @test check_tree(constraint, tree2) == false
             @test check_tree(constraint, tree3) == false
@@ -131,22 +131,22 @@
     @testset "propagation" begin
         @testset "infeasible" begin
             constraint = ForbiddenSequence([1, 2, 3])
-        
+
             test_infeasible(
                 constraint,
                 [1, 2, 3]
             )
-        
+
             test_infeasible(
                 constraint,
                 [1, 2, (1, 2, 3), 3]
             )
-        
+
             test_infeasible(
                 constraint,
                 [1, 2, (1, 2, 3), (1, 2, 3), 3]
             )
-        
+
             test_infeasible(
                 constraint,
                 [1, 2, 3, (1, 2, 3), (1, 2, 3), 3]
@@ -177,7 +177,7 @@
                 [1, (1, 2, 3), 3],
                 [1, (1, 3), 3]
             )
-            
+
             test_propagation(
                 constraint,
                 [1, 2, (1, 2, 3)],
@@ -209,7 +209,7 @@
 
         @testset "infeasible (with ignore_if)" begin
             constraint = ForbiddenSequence([1, 2, 3], ignore_if=[4, 5])
-        
+
             test_infeasible(
                 constraint,
                 [1, 2, 3]
@@ -219,7 +219,7 @@
                 constraint,
                 [(1, 2, 3, 4), 1, 2, 3, (1, 2, 3, 4)]
             )
-        
+
             test_infeasible(
                 constraint,
                 [1, 2, 3, 1, 2, 4, 3]
@@ -294,5 +294,17 @@
                 [1, 2, (4, 5), 3]
             )
         end
+    end
+
+    @testset "update_rule_indices!" begin
+        constraint = ForbiddenSequence([1, 2, 3], [2, 5])
+        n_rules = 10
+        HerbConstraints.update_rule_indices!(constraint, n_rules)
+        @test constraint.sequence == [1, 2, 3]
+        @test constraint.ignore_if == [2, 5]
+        mapping = Dict(1 => 10, 3 => 99, 5 => 6)
+        HerbConstraints.update_rule_indices!(constraint, n_rules, mapping)
+        @test constraint.sequence == [10, 2, 99]
+        @test constraint.ignore_if == [2, 6]
     end
 end

--- a/test/test_grammarconstraints.jl
+++ b/test/test_grammarconstraints.jl
@@ -44,13 +44,15 @@
         add_rule!(grammar, :(Number = 3 | 4))
         @test length(grammar.rules) == 7
 
-        # TODO: check if constraints were updated as expected
-        expected_contains_subtree = ContainsSubtree(UniformHole(BitVector((0, 0, 1, 1, 0, 0, 0)), [RuleNode(2), RuleNode(4, [UniformHole(BitVector((1, 1, 0, 0, 0, 0, 0)), []), UniformHole(BitVector((1, 1, 0, 0, 0, 0, 0)), [])])]))
-        expected_forbidden = Forbidden(tree2)
+        expected_bv1 = BitVector((0, 0, 1, 1, 0, 0, 0))
+        expected_bv2 = BitVector((1, 1, 0, 0, 0, 0, 0))
+        expected_bv3 = BitVector((1, 1, 0, 0, 0, 0, 0))
 
         @test grammar.constraints[1] == Contains(3) # no changes
         @test grammar.constraints[2].sequence == [1, 2, 3] # no changes
-        @test grammar.constraints[3] == expected_contains_subtree # size BV changes
-        @test grammar.constraints[4] == expected_forbidden # no changes
+        @test grammar.constraints[3].tree.domain == expected_bv1# size BV changes
+        @test grammar.constraints[3].tree.children[2].children[1].domain == expected_bv2
+        @test grammar.constraints[3].tree.children[2].children[2].domain == expected_bv3
+        @test grammar.constraints[4].tree == tree2
     end
 end

--- a/test/test_grammarconstraints.jl
+++ b/test/test_grammarconstraints.jl
@@ -1,23 +1,4 @@
 @testset verbose = true "AbstractGrammarConstraint" begin
-    @testset "utils" begin
-        @testset "_get_new_index" begin
-            rule = 8
-            mapping = Dict(1 => 10, 2 => 11, 3 => 12)
-            @test HerbConstraints._get_new_index(rule, mapping) == 8
-            rule = 3
-            @test HerbConstraints._get_new_index(rule, mapping) == 12
-        end
-    end
-    @testset "error" begin
-        struct TestConstraintWithoutImpl <: AbstractGrammarConstraint end
-        n_rules = 5
-        c = TestConstraintWithoutImpl()
-        @test_throws ErrorException HerbCore.update_rule_indices!(c, n_rules)
-        mapping = Dict(1 => 5, 2 => 6, 3 => 1)
-        constraints = [c]
-        @test_throws ErrorException HerbCore.update_rule_indices!(
-            c, n_rules, mapping, constraints)
-    end
     @testset "add_rule! to grammar and update constraints" begin
         # define grammar
         grammar = @cfgrammar begin
@@ -57,11 +38,11 @@
     end
     @testset "merge_grammars! and update constraints" begin
         @testset "Simple example" begin
-            g₁ = @csgrammar begin
+            merge_to = @csgrammar begin
                 Real = |(1:2)
                 Real = x
             end
-            g₂ = @csgrammar begin
+            merge_from = @csgrammar begin
                 Real = Real + Real
                 Real = Real * Real
             end
@@ -69,12 +50,12 @@
             ordered_operations_constraint = Ordered(DomainRuleNode([1, 1], [VarNode(:v), VarNode(:w)]), [:v, :w])
             tree = UniformHole(BitVector((0, 0, 1, 1, 0)), [RuleNode(1), RuleNode(2)])
             contains_subtree_constraint = ContainsSubtree(tree)
-            addconstraint!(g₂, ordered_operations_constraint)
-            addconstraint!(g₂, contains_subtree_constraint)
-            merge_grammars!(g₁, g₂)
+            addconstraint!(merge_from, ordered_operations_constraint)
+            addconstraint!(merge_from, contains_subtree_constraint)
+            merge_grammars!(merge_to, merge_from)
 
-            @test g₁.constraints[1].tree.domain == BitVector((0, 0, 0, 1, 1))
-            @test g₁.constraints[2].tree.children == [RuleNode(4), RuleNode(5)]
+            @test merge_to.constraints[1].tree.domain == BitVector((0, 0, 0, 1, 1))
+            @test merge_to.constraints[2].tree.children == [RuleNode(4), RuleNode(5)]
         end
         @testset "Duplicate rules" begin
             merge_to = @csgrammar begin

--- a/test/test_grammarconstraints.jl
+++ b/test/test_grammarconstraints.jl
@@ -1,0 +1,18 @@
+@testset verbose = true "AbstractGrammarConstraint" begin
+    @testset "utils" begin
+        rule = 8
+        mapping = Dict(1 => 10, 2 => 11, 3 => 12)
+        @test HerbConstraints._get_new_index(rule, mapping) == 8
+        rule = 3
+        @test HerbConstraints._get_new_index(rule, mapping) == 12
+    end
+    @testset "error" begin
+        struct TestConstraintWithoutImpl <: AbstractGrammarConstraint end
+        n_rules = 5
+        constraint = TestConstraintWithoutImpl()
+        @test_throws ErrorException HerbConstraints.update_rule_indices!(constraint, n_rules)
+        mapping = Dict(1 => 5, 2 => 6, 3 => 1)
+        @test_throws ErrorException HerbConstraints.update_rule_indices!(
+            constraint, n_rules, mapping)
+    end
+end

--- a/test/test_grammarconstraints.jl
+++ b/test/test_grammarconstraints.jl
@@ -12,10 +12,10 @@
         struct TestConstraintWithoutImpl <: AbstractGrammarConstraint end
         n_rules = 5
         c = TestConstraintWithoutImpl()
-        @test_throws ErrorException HerbConstraints.update_rule_indices!(c, n_rules)
+        @test_throws ErrorException HerbCore.update_rule_indices!(c, n_rules)
         mapping = Dict(1 => 5, 2 => 6, 3 => 1)
         constraints = [c]
-        @test_throws ErrorException HerbConstraints.update_rule_indices!(
+        @test_throws ErrorException HerbCore.update_rule_indices!(
             c, n_rules, mapping, constraints)
     end
 

--- a/test/test_grammarconstraints.jl
+++ b/test/test_grammarconstraints.jl
@@ -7,37 +7,16 @@
             rule = 3
             @test HerbConstraints._get_new_index(rule, mapping) == 12
         end
-        # @testset "removeconstraint" begin
-        #     grammar = @csgrammar begin
-        #         Int = 1
-        #         Int = x
-        #         Int = -Int
-        #         Int = Int + Int
-        #         Int = Int * Int
-        #     end
-        #     # @test isempty(grammar.constraints) == true
-        #     c = Contains(2)
-        #     addconstraint!(grammar, c)
-        #     @test length(grammar.constraints) == 1
-        #     @test grammar.constraints[1] == Contains(2)
-        #     # # TODO: should there be a get function?
-        #     # # TODO: test replacing constraint
-        #     # mapping = Dict(1 => 5, 2 => 6, 3 => 1)
-        #     # grammar.constraints[1] = Contains(HerbConstraints._get_new_index(c.rule, mapping))
-        #     # println(grammar.constraints)
-        #     index = findfirst(x -> x == c, grammar.constraints)
-        #     println("It's a match! Index: ", index)
-
-        # end
     end
     @testset "error" begin
         struct TestConstraintWithoutImpl <: AbstractGrammarConstraint end
         n_rules = 5
-        constraint = TestConstraintWithoutImpl()
-        @test_throws ErrorException HerbConstraints.update_rule_indices!(constraint, n_rules)
+        c = TestConstraintWithoutImpl()
+        @test_throws ErrorException HerbConstraints.update_rule_indices!(c, n_rules)
         mapping = Dict(1 => 5, 2 => 6, 3 => 1)
+        constraints = [c]
         @test_throws ErrorException HerbConstraints.update_rule_indices!(
-            constraint, n_rules, mapping)
+            c, n_rules, mapping, constraints)
     end
 
 end

--- a/test/test_grammarconstraints.jl
+++ b/test/test_grammarconstraints.jl
@@ -18,5 +18,39 @@
         @test_throws ErrorException HerbCore.update_rule_indices!(
             c, n_rules, mapping, constraints)
     end
+    @testset "Add rules to grammar and update constraints" begin
+        # define grammar
+        grammar = @cfgrammar begin
+            Number = |(1:2)
+            Number = x
+            Number = Number + Number
+            Number = Number * Number
+        end
 
+        # add constraints
+        contains = Contains(3)
+        forbidden_sequence = ForbiddenSequence([1, 2, 3])
+        tree1 = UniformHole(BitVector((0, 0, 1, 1, 0)), [RuleNode(2), RuleNode(4, [UniformHole(BitVector((1, 1, 0, 0, 0)), []), UniformHole(BitVector((1, 1, 0, 0, 0)), [])])])
+        tree2 = RuleNode(4, [VarNode(:a), RuleNode(1)])
+        contains_subtree = ContainsSubtree(tree1)
+        forbidden = Forbidden(tree2)
+
+        addconstraint!(grammar, contains)
+        addconstraint!(grammar, forbidden_sequence)
+        addconstraint!(grammar, contains_subtree)
+        addconstraint!(grammar, forbidden)
+
+        # add more rules to grammar
+        add_rule!(grammar, :(Number = 3 | 4))
+        @test length(grammar.rules) == 7
+
+        # TODO: check if constraints were updated as expected
+        expected_contains_subtree = ContainsSubtree(UniformHole(BitVector((0, 0, 1, 1, 0, 0, 0)), [RuleNode(2), RuleNode(4, [UniformHole(BitVector((1, 1, 0, 0, 0, 0, 0)), []), UniformHole(BitVector((1, 1, 0, 0, 0, 0, 0)), [])])]))
+        expected_forbidden = Forbidden(tree2)
+
+        @test grammar.constraints[1] == Contains(3) # no changes
+        @test grammar.constraints[2].sequence == [1, 2, 3] # no changes
+        @test grammar.constraints[3] == expected_contains_subtree # size BV changes
+        @test grammar.constraints[4] == expected_forbidden # no changes
+    end
 end

--- a/test/test_grammarconstraints.jl
+++ b/test/test_grammarconstraints.jl
@@ -94,8 +94,8 @@
             # Note: addconstraint! (used in merge_grammars!) currently does not check for duplicate constraints. 
             # Might change in the future and some of the tests will need to be updated.
             @test length(merge_to.constraints) == 3
-            @test merge_to.constraints[2] == Contains(1)
-            @test merge_to.constraints[3] == Contains(4)
+            @test Contains(1) in merge_to.constraints
+            @test Contains(4) in merge_to.constraints
         end
     end
 end

--- a/test/test_grammarconstraints.jl
+++ b/test/test_grammarconstraints.jl
@@ -1,10 +1,34 @@
 @testset verbose = true "AbstractGrammarConstraint" begin
     @testset "utils" begin
-        rule = 8
-        mapping = Dict(1 => 10, 2 => 11, 3 => 12)
-        @test HerbConstraints._get_new_index(rule, mapping) == 8
-        rule = 3
-        @test HerbConstraints._get_new_index(rule, mapping) == 12
+        @testset "_get_new_index" begin
+            rule = 8
+            mapping = Dict(1 => 10, 2 => 11, 3 => 12)
+            @test HerbConstraints._get_new_index(rule, mapping) == 8
+            rule = 3
+            @test HerbConstraints._get_new_index(rule, mapping) == 12
+        end
+        # @testset "removeconstraint" begin
+        #     grammar = @csgrammar begin
+        #         Int = 1
+        #         Int = x
+        #         Int = -Int
+        #         Int = Int + Int
+        #         Int = Int * Int
+        #     end
+        #     # @test isempty(grammar.constraints) == true
+        #     c = Contains(2)
+        #     addconstraint!(grammar, c)
+        #     @test length(grammar.constraints) == 1
+        #     @test grammar.constraints[1] == Contains(2)
+        #     # # TODO: should there be a get function?
+        #     # # TODO: test replacing constraint
+        #     # mapping = Dict(1 => 5, 2 => 6, 3 => 1)
+        #     # grammar.constraints[1] = Contains(HerbConstraints._get_new_index(c.rule, mapping))
+        #     # println(grammar.constraints)
+        #     index = findfirst(x -> x == c, grammar.constraints)
+        #     println("It's a match! Index: ", index)
+
+        # end
     end
     @testset "error" begin
         struct TestConstraintWithoutImpl <: AbstractGrammarConstraint end
@@ -15,4 +39,5 @@
         @test_throws ErrorException HerbConstraints.update_rule_indices!(
             constraint, n_rules, mapping)
     end
+
 end

--- a/test/test_ordered.jl
+++ b/test/test_ordered.jl
@@ -167,7 +167,8 @@
         @test check_tree(ordered, tree) == true # constraint pattern not found in tree
 
         mapping = Dict(4 => 10, 2 => 22)
-        HerbConstraints.update_rule_indices!(ordered, n_rules, mapping)
+        constraints = [ordered]
+        HerbConstraints.update_rule_indices!(ordered, n_rules, mapping, constraints)
         @test check_tree(ordered, tree) == false # tree now violates constraint
         @test ordered.tree == RuleNode(10, [
             VarNode(:a),

--- a/test/test_ordered.jl
+++ b/test/test_ordered.jl
@@ -1,9 +1,9 @@
-@testset verbose=false "Ordered" begin
+@testset verbose = false "Ordered" begin
     @testset "check_tree true, length(order)=2" begin
         ordered = Ordered(RuleNode(4, [
-            VarNode(:a),
-            VarNode(:b)
-        ]), [:a, :b])
+                VarNode(:a),
+                VarNode(:b)
+            ]), [:a, :b])
         tree11 = RuleNode(4, [
             RuleNode(1),
             RuleNode(1)
@@ -39,9 +39,9 @@
 
     @testset "check_tree false, length(order)=2" begin
         ordered = Ordered(RuleNode(4, [
-            VarNode(:a),
-            VarNode(:b)
-        ]), [:a, :b])
+                VarNode(:a),
+                VarNode(:b)
+            ]), [:a, :b])
         tree21 = RuleNode(4, [
             RuleNode(2),
             RuleNode(1)
@@ -62,10 +62,10 @@
 
     @testset "check_tree true, length(order)=3" begin
         ordered = Ordered(RuleNode(4, [
-            VarNode(:a),
-            VarNode(:b),
-            VarNode(:c)
-        ]), [:a, :b, :c])
+                VarNode(:a),
+                VarNode(:b),
+                VarNode(:c)
+            ]), [:a, :b, :c])
         tree111 = RuleNode(4, [
             RuleNode(1),
             RuleNode(1),
@@ -115,10 +115,10 @@
 
     @testset "check_tree false, length(order)=3" begin
         ordered = Ordered(RuleNode(4, [
-            VarNode(:a),
-            VarNode(:b),
-            VarNode(:c)
-        ]), [:a, :b, :c])
+                VarNode(:a),
+                VarNode(:b),
+                VarNode(:c)
+            ]), [:a, :b, :c])
         tree121 = RuleNode(4, [
             RuleNode(1),
             RuleNode(2),
@@ -149,5 +149,29 @@
         @test check_tree(ordered, tree121) == false
         @test check_tree(ordered, tree133_leftchild_false) == false
         @test check_tree(ordered, tree133_rightchild_false) == false
+    end
+    @testset "update_rule_indices" begin
+        ordered = Ordered(RuleNode(4, [
+                VarNode(:a),
+                VarNode(:b),
+                VarNode(:c)
+            ]), [:a, :c, :b])
+
+        tree = @rulenode 10{1,5,6}
+        n_rules = 10
+        HerbConstraints.update_rule_indices!(ordered, n_rules)
+        @test ordered.tree == RuleNode(4, [
+            VarNode(:a),
+            VarNode(:b),
+            VarNode(:c)])
+        @test check_tree(ordered, tree) == true # constraint pattern not found in tree
+
+        mapping = Dict(4 => 10, 2 => 22)
+        HerbConstraints.update_rule_indices!(ordered, n_rules, mapping)
+        @test check_tree(ordered, tree) == false # tree now violates constraint
+        @test ordered.tree == RuleNode(10, [
+            VarNode(:a),
+            VarNode(:b),
+            VarNode(:c)])
     end
 end

--- a/test/test_unique.jl
+++ b/test/test_unique.jl
@@ -136,9 +136,8 @@
         mapping = Dict(1 => 5, 2 => 6)
         HerbConstraints.update_rule_indices!(c, n_rules)
         @test grammar.constraints[1] == Unique(1)
-        HerbConstraints.update_rule_indices!(c, grammar.constraints,
-            n_rules,
-            mapping)
+        HerbConstraints.update_rule_indices!(c, n_rules,
+            mapping, grammar.constraints)
         @test grammar.constraints[1] == Unique(5)
     end
 end

--- a/test/test_unique.jl
+++ b/test/test_unique.jl
@@ -1,4 +1,4 @@
-@testset verbose=false "Unique" begin
+@testset verbose = false "Unique" begin
     grammar = @csgrammar begin
         Number = x | 1
         Number = Number + Number
@@ -30,7 +30,7 @@
                 RuleNode(2)
             ])
         ])
-        
+
         tree_one_leaf = RuleNode(3, [
             RuleNode(3, [
                 RuleNode(1),
@@ -128,5 +128,17 @@
         @test number_of_holes(tree) == 2
         @test length(findall(get_node_at_location(tree, [1, 1]).domain)) == 3
         @test length(findall(get_node_at_location(tree, [2, 2]).domain)) == 3
+    end
+
+    @testset "update_rule_indices!" begin
+        c = Unique(1)
+        n_rules = 5
+        mapping = Dict(1 => 5, 2 => 6)
+        HerbConstraints.update_rule_indices!(c, n_rules)
+        @test grammar.constraints[1] == Unique(1)
+        HerbConstraints.update_rule_indices!(c, grammar.constraints,
+            n_rules,
+            mapping)
+        @test grammar.constraints[1] == Unique(5)
     end
 end

--- a/test/test_unique.jl
+++ b/test/test_unique.jl
@@ -131,13 +131,27 @@
     end
 
     @testset "update_rule_indices!" begin
-        c = Unique(1)
-        n_rules = 5
-        mapping = Dict(1 => 5, 2 => 6)
-        HerbConstraints.update_rule_indices!(c, n_rules)
-        @test grammar.constraints[1] == Unique(1)
-        HerbConstraints.update_rule_indices!(c, n_rules,
-            mapping, grammar.constraints)
-        @test grammar.constraints[1] == Unique(5)
+        @testset "interface without grammar" begin
+            c = Unique(1)
+            n_rules = 5
+            mapping = Dict(1 => 5, 2 => 6)
+            HerbCore.update_rule_indices!(c, n_rules)
+            @test grammar.constraints[1] == Unique(1)
+            HerbCore.update_rule_indices!(c, n_rules,
+                mapping, grammar.constraints)
+            @test grammar.constraints[1] == Unique(5)
+        end
+        @testset "interface with grammar" begin
+            clearconstraints!(grammar)
+            c = Unique(1)
+            addconstraint!(grammar, c)
+
+            HerbCore.update_rule_indices!(c, grammar)
+            @test grammar.constraints[1] == Unique(1)
+            mapping = Dict(1 => 5, 2 => 6)
+            HerbCore.update_rule_indices!(c, grammar,
+                mapping)
+            @test grammar.constraints[1] == Unique(5)
+        end
     end
 end

--- a/test/test_unique.jl
+++ b/test/test_unique.jl
@@ -153,5 +153,11 @@
                 mapping)
             @test grammar.constraints[1] == Unique(5)
         end
+        @testset "error" begin
+            clearconstraints!(grammar)
+            c = Unique(23)
+            addconstraint!(grammar, c)
+            @test_throws ErrorException HerbCore.update_rule_indices!(c, grammar)
+        end
     end
 end

--- a/test/test_varnode.jl
+++ b/test/test_varnode.jl
@@ -1,16 +1,25 @@
-@testset verbose=false "VarNode" begin
+@testset verbose = false "VarNode" begin
 
     @testset "number_of_varnodes" begin
         @test HerbConstraints.contains_varnode(RuleNode(1), :a) == false
         @test HerbConstraints.contains_varnode(VarNode(:a), :a) == true
         @test HerbConstraints.contains_varnode(VarNode(:b), :a) == false
         @test HerbConstraints.contains_varnode(RuleNode(2, [
-            VarNode(:b),
-            VarNode(:a)
-        ]), :a) == true
+                VarNode(:b),
+                VarNode(:a)
+            ]), :a) == true
         @test HerbConstraints.contains_varnode(RuleNode(2, [
-            VarNode(:b),
-            VarNode(:b)
-        ]), :a) == false
+                VarNode(:b),
+                VarNode(:b)
+            ]), :a) == false
+    end
+    @testset "update_rule_indices" begin
+        n_rules = 100
+        mapping = Dict(1 => 3, 5 => 99)
+        node = VarNode(:b)
+        HerbCore.update_rule_indices!(node, n_rules)
+        @test node == VarNode(:b)
+        HerbCore.update_rule_indices!(node, n_rules, mapping)
+        @test node == VarNode(:b)
     end
 end


### PR DESCRIPTION
## Update constraints when grammar changes

Based on the relevant scenarios we identified so far where constraints need to be updated, we have four different interfaces that need to be implemented for each subtype of `AbstractGrammarConstraint`.

### Scenario 1: Add rules to grammar with `add_rule!()`
```
function HerbCore.update_rule_indices!(c::AbstractGrammarConstraint, n_rules::Integer)
function HerbCore.update_rule_indices!(c::AbstractGrammarConstraint, grammar::AbstractGrammar)
```
Note: 2. is just a wrapper around 1. that extracts number of grammar rules `n_rules` directly from grammar.

### Scenario 2: Merge two grammar with `merge_grammars!()`
Scenario 2 requires additional args. A mapping from old to new rule indices and the constraint vector of the grammar need to be provided. The latter is needed since some constraints (Contains, Unique) can only be updated by replacing the relevant element in the constraint vector with a new constraint.
```
function HerbCore.update_rule_indices!(c::AbstractGrammarConstraint, n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer}, constraints::Vector{<:AbstractConstraint})
function HerbCore.update_rule_indices!(c::AbstractGrammarConstraint, grammar::AbstractGrammar, mapping::AbstractDict{<:Integer,<:Integer}
```
Note: 4. is just a wrapper around 2. that extracts `n_rules` and constraints directly from grammar.


## Tests

`update_rule_indices!(c::AbstractGrammarConstraint, ...)` is called in `HerbGrammar.add_rule!` and `HerbGrammar.merge_grammars!`. Since `HerbGrammar` doesn't have `HerbConstraint` as a dependency (and adding it would result in a circular dependency), tests that check if the constraints are updated correctly when using `add_rule!` and `merge_grammars!` were added to `HerbConstraints` instead of `HerbGrammar`.