### PR TITLE
Fix/enforce constraint domain

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbConstraints"
 uuid = "1fa96474-3206-4513-b4fa-23913f296dfc"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/domainrulenode.jl
+++ b/src/domainrulenode.jl
@@ -77,3 +77,10 @@ function HerbCore.update_rule_indices!(
         HerbCore.update_rule_indices!(child, n_rules, mapping)
     end
 end
+"""Check if `DomainRuleNode`'s domain length matches `n_rules`."""
+function HerbCore.is_domain_valid(node::DomainRuleNode, n_rules::Integer)
+    if length(node.domain) != n_rules
+        return false
+    end
+    all(child -> HerbCore.is_domain_valid(child, n_rules), get_children(node))
+end

--- a/src/domainrulenode.jl
+++ b/src/domainrulenode.jl
@@ -77,7 +77,8 @@ function HerbCore.update_rule_indices!(
         HerbCore.update_rule_indices!(child, n_rules, mapping)
     end
 end
-"""Check if `DomainRuleNode`'s domain length matches `n_rules`."""
+
+# Check if `DomainRuleNode`'s domain length matches `n_rules`.
 function HerbCore.is_domain_valid(node::DomainRuleNode, n_rules::Integer)
     if length(node.domain) != n_rules
         return false

--- a/src/grammarconstraints/contains.jl
+++ b/src/grammarconstraints/contains.jl
@@ -101,3 +101,6 @@ function HerbCore.update_rule_indices!(c::Contains,
     mapping::AbstractDict{<:Integer,<:Integer})
     HerbCore.update_rule_indices!(c, length(grammar.rules), mapping, grammar.constraints)
 end
+
+HerbCore.is_domain_valid(c::Contains, n_rules::Integer) = c.rule <= n_rules
+HerbCore.is_domain_valid(c::Contains, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c, length(grammar.rules))

--- a/src/grammarconstraints/contains_subtree.jl
+++ b/src/grammarconstraints/contains_subtree.jl
@@ -98,3 +98,6 @@ function HerbCore.update_rule_indices!(
 )
     HerbCore.update_rule_indices!(c, length(grammar.rules), mapping, grammar.constraints)
 end
+
+HerbCore.is_domain_valid(c::ContainsSubtree, n_rules::Integer) = HerbCore.is_domain_valid(c.tree, n_rules)
+HerbCore.is_domain_valid(c::ContainsSubtree, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c.tree, length(grammar.rules))

--- a/src/grammarconstraints/forbidden.jl
+++ b/src/grammarconstraints/forbidden.jl
@@ -125,3 +125,6 @@ function HerbCore.update_rule_indices!(
 )
     HerbCore.update_rule_indices!(c, length(grammar.rules), mapping, grammar.constraints)
 end
+
+HerbCore.is_domain_valid(c::Forbidden, n_rules::Integer) = HerbCore.is_domain_valid(c.tree, n_rules)
+HerbCore.is_domain_valid(c::Forbidden, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c.tree, length(grammar.rules))

--- a/src/grammarconstraints/forbidden_sequence.jl
+++ b/src/grammarconstraints/forbidden_sequence.jl
@@ -156,3 +156,6 @@ function HerbCore.update_rule_indices!(
 )
     HerbCore.update_rule_indices!(c, length(grammar.rules), mapping, grammar.constraints)
 end
+
+HerbCore.is_domain_valid(c::ForbiddenSequence, n_rules::Integer) = all(i -> i <= n_rules, c.sequence) && all(i -> i <= n_rules, c.ignore_if)
+HerbCore.is_domain_valid(c::ForbiddenSequence, grammar::ContextSensitiveGrammar) = HerbCore.is_domain_valid(c, length(grammar.rules))

--- a/src/grammarconstraints/ordered.jl
+++ b/src/grammarconstraints/ordered.jl
@@ -130,3 +130,6 @@ function HerbCore.update_rule_indices!(
 )
     HerbCore.update_rule_indices!(c, length(grammar.rules), mapping, grammar.constraints)
 end
+
+HerbCore.is_domain_valid(c::Ordered, n_rules::Integer) = HerbCore.is_domain_valid(c.tree, n_rules)
+HerbCore.is_domain_valid(c::Ordered, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c.tree, length(grammar.rules))

--- a/src/grammarconstraints/unique.jl
+++ b/src/grammarconstraints/unique.jl
@@ -115,3 +115,6 @@ function HerbCore.update_rule_indices!(c::Unique,
     mapping::AbstractDict{<:Integer,<:Integer})
     HerbCore.update_rule_indices!(c, length(grammar.rules), mapping, grammar.constraints)
 end
+
+HerbCore.is_domain_valid(c::Unique, n_rules::Integer) = c.rule <= n_rules
+HerbCore.is_domain_valid(c::Unique, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c, length(grammar.rules))

--- a/src/varnode.jl
+++ b/src/varnode.jl
@@ -57,3 +57,6 @@ function HerbCore.update_rule_indices!(
 )
     # VarNode does not change
 end
+
+"""Always return `true` (interface only)"""
+HerbCore.is_domain_valid(node::VarNode, n_rules::Integer) = true

--- a/src/varnode.jl
+++ b/src/varnode.jl
@@ -58,5 +58,5 @@ function HerbCore.update_rule_indices!(
     # VarNode does not change
 end
 
-"""Always return `true` (interface only)"""
+# Always return `true` (interface only)
 HerbCore.is_domain_valid(node::VarNode, n_rules::Integer) = true

--- a/test/test_contains.jl
+++ b/test/test_contains.jl
@@ -68,4 +68,15 @@
             @test_throws ErrorException HerbCore.update_rule_indices!(c, grammar)
         end
     end
+    @testset "is_domain_valid" begin
+        grammar = @csgrammar begin
+            Int = 1
+            Int = x
+            Int = -Int
+            Int = Int + Int
+            Int = Int * Int
+        end
+        @test HerbCore.is_domain_valid(Contains(8), grammar) == false
+        @test HerbCore.is_domain_valid(Contains(3), grammar) == true
+    end
 end

--- a/test/test_contains.jl
+++ b/test/test_contains.jl
@@ -62,10 +62,9 @@
             @test Contains(6) in grammar.constraints
         end
         @testset "error" begin
-            clearconstraints!(grammar)
             c = Contains(23)
-            addconstraint!(grammar, c)
-            @test_throws ErrorException HerbCore.update_rule_indices!(c, grammar)
+            n_rules = 10
+            @test_throws ErrorException HerbCore.update_rule_indices!(c, n_rules)
         end
     end
     @testset "is_domain_valid" begin

--- a/test/test_contains_subtree.jl
+++ b/test/test_contains_subtree.jl
@@ -342,4 +342,21 @@
         end
 
     end
+    @testset verbose = true "is_domain_valid" begin
+        grammar = @csgrammar begin
+            Int = 1
+            Int = x
+            Int = -Int
+            Int = Int + Int
+            Int = Int * Int
+        end
+        contains_subtree = ContainsSubtree(
+            RuleNode(5, [
+                VarNode(:a),
+                VarNode(:a),
+            ]),
+        )
+        @test HerbCore.is_domain_valid(contains_subtree, grammar) == true
+
+    end
 end

--- a/test/test_domainrulenode.jl
+++ b/test/test_domainrulenode.jl
@@ -30,4 +30,11 @@
         n_rules = 3
         @test_throws ErrorException HerbCore.update_rule_indices!(node, n_rules)
     end
+    @testset "is_domain_valid" begin
+        node1 = DomainRuleNode(BitVector((1, 0)), [DomainRuleNode(BitVector((1, 1, 0, 0, 0))), DomainRuleNode(BitVector((0, 1)))])
+        node2 = DomainRuleNode(BitVector((1, 0)), [DomainRuleNode(BitVector((1, 1))), DomainRuleNode(BitVector((0, 1)))])
+        n_rules = 2
+        @test HerbCore.is_domain_valid(node1, n_rules) == false
+        @test HerbCore.is_domain_valid(node2, n_rules) == true
+    end
 end

--- a/test/test_forbidden.jl
+++ b/test/test_forbidden.jl
@@ -102,4 +102,17 @@
             @test forbidden.tree == expected_forbidden.tree
         end
     end
+    @testset "is_domain_valid" begin
+        grammar = @csgrammar begin
+            Int = 1
+            Int = x
+            Int = -Int
+            Int = Int + Int
+            Int = Int * Int
+        end
+        forbidden1 = Forbidden(RuleNode(3, [RuleNode(5), RuleNode(8)]))
+        forbidden2 = Forbidden(RuleNode(3, [VarNode(:a), VarNode(:a)]))
+        @test HerbCore.is_domain_valid(forbidden1, grammar) == false
+        @test HerbCore.is_domain_valid(forbidden2, grammar) == true
+    end
 end

--- a/test/test_forbidden_sequence.jl
+++ b/test/test_forbidden_sequence.jl
@@ -328,16 +328,9 @@
             @test grammar.constraints[1].ignore_if == [2, 6]
         end
         @testset "error" begin
-            grammar = @csgrammar begin
-                Int = 1
-                Int = x
-                Int = -Int
-                Int = Int + Int
-                Int = Int * Int
-            end
             c = ForbiddenSequence([1, 2, 10], [2, 5])
-            addconstraint!(grammar, c)
-            @test_throws ErrorException HerbCore.update_rule_indices!(c, grammar)
+            n_rules = 5
+            @test_throws ErrorException HerbCore.update_rule_indices!(c, n_rules)
         end
     end
     @testset "is_domain_valid" begin

--- a/test/test_forbidden_sequence.jl
+++ b/test/test_forbidden_sequence.jl
@@ -340,4 +340,17 @@
             @test_throws ErrorException HerbCore.update_rule_indices!(c, grammar)
         end
     end
+    @testset "is_domain_valid" begin
+        grammar = @csgrammar begin
+            Int = 1
+            Int = x
+            Int = -Int
+            Int = Int + Int
+            Int = Int * Int
+        end
+        constraint1 = ForbiddenSequence([1, 2, 3], ignore_if=[4, 5, 6, 7, 8])
+        @test HerbCore.is_domain_valid(constraint1, grammar) == false
+        constraint2 = ForbiddenSequence([1, 2, 3], ignore_if=[4, 5])
+        @test HerbCore.is_domain_valid(constraint2, grammar) == true
+    end
 end

--- a/test/test_grammarconstraints.jl
+++ b/test/test_grammarconstraints.jl
@@ -46,16 +46,24 @@
                 Real = Real + Real
                 Real = Real * Real
             end
-            # TODO: update tests to make sense with addconstraint! that checks if domain is valid
-            ordered_operations_constraint = Ordered(DomainRuleNode([1, 1], [VarNode(:v), VarNode(:w)]), [:v, :w])
-            tree = UniformHole(BitVector((0, 0, 1, 1, 0)), [RuleNode(1), RuleNode(2)])
-            contains_subtree_constraint = ContainsSubtree(tree)
-            addconstraint!(merge_from, ordered_operations_constraint)
-            addconstraint!(merge_from, contains_subtree_constraint)
-            # merge_grammars!(merge_to, merge_from)
 
-            # @test merge_to.constraints[1].tree.domain == BitVector((0, 0, 0, 1, 1))
-            # @test merge_to.constraints[2].tree.children == [RuleNode(4), RuleNode(5)]
+            forbidden = Forbidden(UniformHole(BitVector((0, 0, 1))))
+            ordered = Ordered(DomainRuleNode([1, 1], [VarNode(:v), VarNode(:w)]), [:v, :w])
+            tree = UniformHole(BitVector((1, 0)), [RuleNode(1), RuleNode(2)])
+            contains_subtree = ContainsSubtree(tree)
+            addconstraint!(merge_to, forbidden)
+            addconstraint!(merge_from, ordered)
+            addconstraint!(merge_from, contains_subtree)
+
+            merge_grammars!(merge_to, merge_from)
+            # test that merge_grammars! does not modify merge_from.constraints
+            @test length(merge_from.constraints) == 2
+            @test merge_from.constraints[1].tree.domain == BitVector((1, 1))
+            # test that rule nodes were updated correctly
+            @test merge_to.constraints[1].tree.domain == BitVector((0, 0, 1, 0, 0))
+            @test merge_to.constraints[2].tree.domain == BitVector((0, 0, 0, 1, 1))
+            @test merge_to.constraints[3].tree.domain == BitVector((0, 0, 0, 1, 0))
+            @test merge_to.constraints[3].tree.children == [RuleNode(4), RuleNode(5)]
         end
         @testset "Duplicate rules" begin
             merge_to = @csgrammar begin
@@ -89,5 +97,6 @@
         # valid domains
         @test isempty(grammar.constraints) == true
         # invalid domains
+        # TODO: continue
     end
 end

--- a/test/test_grammarconstraints.jl
+++ b/test/test_grammarconstraints.jl
@@ -46,16 +46,16 @@
                 Real = Real + Real
                 Real = Real * Real
             end
-
+            # TODO: update tests to make sense with addconstraint! that checks if domain is valid
             ordered_operations_constraint = Ordered(DomainRuleNode([1, 1], [VarNode(:v), VarNode(:w)]), [:v, :w])
             tree = UniformHole(BitVector((0, 0, 1, 1, 0)), [RuleNode(1), RuleNode(2)])
             contains_subtree_constraint = ContainsSubtree(tree)
             addconstraint!(merge_from, ordered_operations_constraint)
             addconstraint!(merge_from, contains_subtree_constraint)
-            merge_grammars!(merge_to, merge_from)
+            # merge_grammars!(merge_to, merge_from)
 
-            @test merge_to.constraints[1].tree.domain == BitVector((0, 0, 0, 1, 1))
-            @test merge_to.constraints[2].tree.children == [RuleNode(4), RuleNode(5)]
+            # @test merge_to.constraints[1].tree.domain == BitVector((0, 0, 0, 1, 1))
+            # @test merge_to.constraints[2].tree.children == [RuleNode(4), RuleNode(5)]
         end
         @testset "Duplicate rules" begin
             merge_to = @csgrammar begin
@@ -78,5 +78,16 @@
             @test Contains(1) in merge_to.constraints
             @test Contains(4) in merge_to.constraints
         end
+    end
+    @testset "addconstraint!" begin
+        grammar = @cfgrammar begin
+            Number = |(1:2)
+            Number = x
+            Number = Number + Number
+            Number = Number * Number
+        end
+        # valid domains
+        @test isempty(grammar.constraints) == true
+        # invalid domains
     end
 end

--- a/test/test_grammarconstraints.jl
+++ b/test/test_grammarconstraints.jl
@@ -96,7 +96,12 @@
         end
         # valid domains
         @test isempty(grammar.constraints) == true
+        forbidden = Forbidden(UniformHole(BitVector((0, 0, 1, 0, 0))))
+        addconstraint!(grammar, forbidden)
+        @test length(grammar.constraints) == 1
+
         # invalid domains
-        # TODO: continue
+        forbidden_invalid = Forbidden(UniformHole(BitVector((0, 0, 1))))
+        @test_throws ErrorException addconstraint!(grammar, forbidden_invalid)
     end
 end

--- a/test/test_ordered.jl
+++ b/test/test_ordered.jl
@@ -208,4 +208,24 @@
                 VarNode(:c)])
         end
     end
+    @testset "is_domain_valid" begin
+        grammar = @csgrammar begin
+            Int = 1
+            Int = x
+            Int = -Int
+            Int = Int + Int
+            Int = Int * Int
+        end
+        ordered1 = Ordered(RuleNode(4, [
+                VarNode(:a),
+                VarNode(:b)
+            ]), [:a, :b])
+        ordered2 = Ordered(RuleNode(31, [
+                VarNode(:a),
+                VarNode(:b)
+            ]), [:a, :b])
+        @test HerbCore.is_domain_valid(ordered1, grammar) == true
+        @test HerbCore.is_domain_valid(ordered2, grammar) == false
+
+    end
 end

--- a/test/test_unique.jl
+++ b/test/test_unique.jl
@@ -154,10 +154,9 @@
             @test grammar.constraints[1] == Unique(5)
         end
         @testset "error" begin
-            clearconstraints!(grammar)
             c = Unique(23)
-            addconstraint!(grammar, c)
-            @test_throws ErrorException HerbCore.update_rule_indices!(c, grammar)
+            n_rules = 10
+            @test_throws ErrorException HerbCore.update_rule_indices!(c, n_rules)
         end
     end
     @testset "is_domain_valid" begin

--- a/test/test_unique.jl
+++ b/test/test_unique.jl
@@ -160,4 +160,15 @@
             @test_throws ErrorException HerbCore.update_rule_indices!(c, grammar)
         end
     end
+    @testset "is_domain_valid" begin
+        grammar = @csgrammar begin
+            Int = 1
+            Int = x
+            Int = -Int
+            Int = Int + Int
+            Int = Int * Int
+        end
+        @test HerbCore.is_domain_valid(Unique(8), grammar) == false
+        @test HerbCore.is_domain_valid(Unique(3), grammar) == true
+    end
 end

--- a/test/test_varnode.jl
+++ b/test/test_varnode.jl
@@ -22,4 +22,7 @@
         HerbCore.update_rule_indices!(node, n_rules, mapping)
         @test node == VarNode(:b)
     end
+    @testset "is_domain_valid" begin
+        @test HerbCore.is_domain_valid(VarNode(:a), 99) == true
+    end
 end


### PR DESCRIPTION
This PR implements `is_domain_valid` for grammar constraints and node types. 

More specifically, it implements
- two interfaces for each constraint type (`is_domain_valid(c::..., n_rules::Integer)` and `is_domain_valid(c::..., grammar::AbstractGrammar)`).
- interface for  `VarNode` and `DomainRuleNode`
- tests for `addconstraint!` 
- tests for `merge_grammars!` (uses `addconstraint!`)

Partly addresses Herb-AI/HerbGrammar.jl#115