### PR TITLE
`removeconstraints!` undefined

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,8 +18,3 @@ MLStyle = "^0.4.17"
 TimerOutputs = "0.5.28"
 julia = "1.10"
 
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbConstraints"
 uuid = "1fa96474-3206-4513-b4fa-23913f296dfc"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -147,7 +147,6 @@ export
     #state fixed shaped hole
     StateHole,
     freeze_state,
-    update_rule_indices!,
-    removeconstraint!
+    update_rule_indices!
 
 end # module HerbConstraints

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
+HerbGrammar = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,11 @@
+using Aqua
 using HerbCore
 using HerbConstraints
 using HerbGrammar
 using Test
 
 @testset "HerbConstraints.jl" verbose = true begin
+    @testset "Aqua.jl" Aqua.test_all(HerbConstraints)
     include("test_domain_utils.jl")
     include("test_treemanipulations.jl")
     include("test_varnode.jl")


### PR DESCRIPTION
Caught an undefined export when updating `Herb.jl` with the latest `HerbConstraints` version in https://github.com/Herb-AI/Herb.jl/pull/165.

This PR removes that export and adds `Aqua` testing in `HerbConstraints` directly to catch issues like this in the future.

I also moved the test project dependencies to their own `test/Project.toml` file, as it keeps the main `Project.toml` a little cleaner 😄 