### PR TITLE
Bump patch for release of #96

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbConstraints"
 uuid = "1fa96474-3206-4513-b4fa-23913f296dfc"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"


### PR DESCRIPTION
I claimed to bump the patch version in https://github.com/Herb-AI/HerbConstraints.jl/pull/96, but I was working off of an old version, so I bumped to the current version number 🤥 