### PR TITLE
Feat/116 duplicate constraints

### DIFF
--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -42,6 +42,12 @@ function get_priority(::AbstractLocalConstraint)
     return 0
 end
 
+"""
+    issame(::AbstractGrammarConstraint, ::AbstractGrammarConstraint)
+
+Default implementation.
+"""
+HerbCore.issame(::AbstractGrammarConstraint, ::AbstractGrammarConstraint) = false # TODO: default in HerbCore?
 
 include("csg_annotated/csg_annotated.jl")
 
@@ -148,6 +154,7 @@ export
     StateHole,
     freeze_state,
     update_rule_indices!,
-    removeconstraint!
+    removeconstraint!,
+    issame
 
 end # module HerbConstraints

--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -42,13 +42,6 @@ function get_priority(::AbstractLocalConstraint)
     return 0
 end
 
-"""
-    issame(::AbstractGrammarConstraint, ::AbstractGrammarConstraint)
-
-Default implementation.
-"""
-HerbCore.issame(::AbstractGrammarConstraint, ::AbstractGrammarConstraint) = false # TODO: default in HerbCore?
-
 include("csg_annotated/csg_annotated.jl")
 
 include("varnode.jl")

--- a/src/domainrulenode.jl
+++ b/src/domainrulenode.jl
@@ -84,3 +84,9 @@ function HerbCore.is_domain_valid(node::DomainRuleNode, n_rules::Integer)
     end
     all(child -> HerbCore.is_domain_valid(child, n_rules), get_children(node))
 end
+
+function HerbCore.issame(A::DomainRuleNode, B::DomainRuleNode)
+
+    A.domain == B.domain && length(A.children) == length(B.children) && all(HerbCore.issame(a, b) for (a, b) in zip(A.children, B.children))
+
+end

--- a/src/grammarconstraints/contains.jl
+++ b/src/grammarconstraints/contains.jl
@@ -104,3 +104,5 @@ end
 
 HerbCore.is_domain_valid(c::Contains, n_rules::Integer) = c.rule <= n_rules
 HerbCore.is_domain_valid(c::Contains, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c, length(grammar.rules))
+
+HerbCore.issame(c1::Contains, c2::Contains) = c1 == c2

--- a/src/grammarconstraints/contains_subtree.jl
+++ b/src/grammarconstraints/contains_subtree.jl
@@ -101,3 +101,5 @@ end
 
 HerbCore.is_domain_valid(c::ContainsSubtree, n_rules::Integer) = HerbCore.is_domain_valid(c.tree, n_rules)
 HerbCore.is_domain_valid(c::ContainsSubtree, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c.tree, length(grammar.rules))
+
+HerbCore.issame(c1::ContainsSubtree, c2::ContainsSubtree) = HerbCore.issame(c1.tree, c2.tree)

--- a/src/grammarconstraints/forbidden.jl
+++ b/src/grammarconstraints/forbidden.jl
@@ -128,3 +128,5 @@ end
 
 HerbCore.is_domain_valid(c::Forbidden, n_rules::Integer) = HerbCore.is_domain_valid(c.tree, n_rules)
 HerbCore.is_domain_valid(c::Forbidden, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c.tree, length(grammar.rules))
+
+HerbCore.issame(c1::Forbidden, c2::Forbidden) = HerbCore.issame(c1.tree, c2.tree)

--- a/src/grammarconstraints/forbidden_sequence.jl
+++ b/src/grammarconstraints/forbidden_sequence.jl
@@ -159,3 +159,5 @@ end
 
 HerbCore.is_domain_valid(c::ForbiddenSequence, n_rules::Integer) = all(i -> i <= n_rules, c.sequence) && all(i -> i <= n_rules, c.ignore_if)
 HerbCore.is_domain_valid(c::ForbiddenSequence, grammar::ContextSensitiveGrammar) = HerbCore.is_domain_valid(c, length(grammar.rules))
+
+HerbCore.issame(c1::ForbiddenSequence, c2::ForbiddenSequence) = (c1.sequence == c2.sequence) && (c1.ignore_if == c2.ignore_if)

--- a/src/grammarconstraints/ordered.jl
+++ b/src/grammarconstraints/ordered.jl
@@ -133,3 +133,5 @@ end
 
 HerbCore.is_domain_valid(c::Ordered, n_rules::Integer) = HerbCore.is_domain_valid(c.tree, n_rules)
 HerbCore.is_domain_valid(c::Ordered, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c.tree, length(grammar.rules))
+
+HerbCore.issame(c1::Ordered, c2::Ordered) = HerbCore.issame(c1.tree, c2.tree) && c1.order == c2.order

--- a/src/grammarconstraints/unique.jl
+++ b/src/grammarconstraints/unique.jl
@@ -118,3 +118,5 @@ end
 
 HerbCore.is_domain_valid(c::Unique, n_rules::Integer) = c.rule <= n_rules
 HerbCore.is_domain_valid(c::Unique, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c, length(grammar.rules))
+
+HerbCore.issame(c1::Unique, c2::Unique) = c1 == c2

--- a/src/varnode.jl
+++ b/src/varnode.jl
@@ -60,3 +60,5 @@ end
 
 """Always return `true` (interface only)"""
 HerbCore.is_domain_valid(node::VarNode, n_rules::Integer) = true
+
+HerbCore.issame(A::VarNode, B::VarNode) = A.name == B.name

--- a/test/test_contains.jl
+++ b/test/test_contains.jl
@@ -78,4 +78,8 @@
         @test HerbCore.is_domain_valid(Contains(8), grammar) == false
         @test HerbCore.is_domain_valid(Contains(3), grammar) == true
     end
+    @testset "issame" begin
+        HerbCore.issame(Contains(12), Contains(12)) == true
+        HerbCore.issame(Contains(12), Contains(12222)) == false
+    end
 end

--- a/test/test_contains_subtree.jl
+++ b/test/test_contains_subtree.jl
@@ -357,6 +357,23 @@
             ]),
         )
         @test HerbCore.is_domain_valid(contains_subtree, grammar) == true
-
+    end
+    @testset "issame" begin
+        tree1 = UniformHole(BitVector((0, 0, 1, 1)), [
+            RuleNode(1),
+            RuleNode(4, [
+                UniformHole(BitVector((1, 1, 0, 0)), []),
+                UniformHole(BitVector((1, 1, 0, 0)), [])
+            ])
+        ])
+        tree2 = UniformHole(BitVector((0, 0, 1, 1)), [
+            RuleNode(1),
+            RuleNode(4, [
+                UniformHole(BitVector((1, 1, 0, 0)), []),
+                UniformHole(BitVector((1, 1, 1, 0)), [])
+            ])
+        ])
+        @test HerbCore.issame(ContainsSubtree(tree1), ContainsSubtree(tree1)) == true
+        @test HerbCore.issame(ContainsSubtree(tree1), ContainsSubtree(tree2)) == false
     end
 end

--- a/test/test_domainrulenode.jl
+++ b/test/test_domainrulenode.jl
@@ -37,4 +37,13 @@
         @test HerbCore.is_domain_valid(node1, n_rules) == false
         @test HerbCore.is_domain_valid(node2, n_rules) == true
     end
+    @testset "issame" begin
+
+        node1 = DomainRuleNode(BitVector((1, 0)), [DomainRuleNode(BitVector((1, 1))), DomainRuleNode(BitVector((0, 1)))])
+        node2 = DomainRuleNode(BitVector((1, 0)), [DomainRuleNode(BitVector((1, 1))), DomainRuleNode(BitVector((0, 1)))])
+        node3 = DomainRuleNode(BitVector((1, 0)))
+        @test HerbCore.issame(node1, node2) == true
+        @test HerbCore.issame(node2, node3) == false
+
+    end
 end

--- a/test/test_forbidden.jl
+++ b/test/test_forbidden.jl
@@ -115,4 +115,20 @@
         @test HerbCore.is_domain_valid(forbidden1, grammar) == false
         @test HerbCore.is_domain_valid(forbidden2, grammar) == true
     end
+    @testset "issame" begin
+        forbidden1 = Forbidden(RuleNode(4, [
+            VarNode(:a),
+            VarNode(:a)
+        ]))
+        forbidden2 = Forbidden(RuleNode(4, [
+            VarNode(:a),
+            VarNode(:a)
+        ]))
+        forbidden3 = Forbidden(RuleNode(4, [
+            VarNode(:b),
+            VarNode(:b)
+        ]))
+        @test HerbCore.issame(forbidden1, forbidden2) == true
+        @test HerbCore.issame(forbidden1, forbidden3) == false
+    end
 end

--- a/test/test_forbidden_sequence.jl
+++ b/test/test_forbidden_sequence.jl
@@ -346,4 +346,13 @@
         constraint2 = ForbiddenSequence([1, 2, 3], ignore_if=[4, 5])
         @test HerbCore.is_domain_valid(constraint2, grammar) == true
     end
+    @testset "issame" begin
+        constraint1 = ForbiddenSequence([1, 2, 3], ignore_if=[4, 5, 6, 7, 8])
+        constraint2 = ForbiddenSequence([1, 2, 3], ignore_if=[4, 5, 6, 7, 8])
+        constraint3 = ForbiddenSequence([1, 2, 3], ignore_if=[4, 5, 6])
+        constraint4 = ForbiddenSequence([1, 2, 5], ignore_if=[4, 5, 6])
+        @test HerbCore.issame(constraint1, constraint2) == true
+        @test HerbCore.issame(constraint1, constraint3) == false
+        @test HerbCore.issame(constraint3, constraint4) == false
+    end
 end

--- a/test/test_grammarconstraints.jl
+++ b/test/test_grammarconstraints.jl
@@ -80,9 +80,7 @@
             addconstraint!(merge_from, Contains(3))
 
             merge_grammars!(merge_to, merge_from)
-            # Note: addconstraint! (used in merge_grammars!) currently does not check for duplicate constraints. 
-            # Might change in the future and some of the tests will need to be updated.
-            @test length(merge_to.constraints) == 3
+            @test length(merge_to.constraints) == 2 # duplicate constraint 
             @test Contains(1) in merge_to.constraints
             @test Contains(4) in merge_to.constraints
         end
@@ -99,9 +97,21 @@
         forbidden = Forbidden(UniformHole(BitVector((0, 0, 1, 0, 0))))
         addconstraint!(grammar, forbidden)
         @test length(grammar.constraints) == 1
+        addconstraint!(grammar, Unique(2))
+        @test length(grammar.constraints) == 2
+
+        # try to add same constraint again
+        addconstraint!(grammar, forbidden)
+        @test length(grammar.constraints) == 2
+
 
         # invalid domains
         forbidden_invalid = Forbidden(UniformHole(BitVector((0, 0, 1))))
         @test_throws ErrorException addconstraint!(grammar, forbidden_invalid)
+
+
+    end
+    @testset "issame" begin
+        @test HerbCore.issame(Contains(1), Unique(1)) == false
     end
 end

--- a/test/test_ordered.jl
+++ b/test/test_ordered.jl
@@ -228,4 +228,21 @@
         @test HerbCore.is_domain_valid(ordered2, grammar) == false
 
     end
+    @testset "issame" begin
+        ordered1 = Ordered(RuleNode(4, [
+                VarNode(:a),
+                VarNode(:b)
+            ]), [:a, :b])
+        ordered2 = Ordered(RuleNode(4, [
+                VarNode(:a),
+                VarNode(:b)
+            ]), [:a, :b])
+        ordered3 = Ordered(RuleNode(4, [
+                VarNode(:a),
+                VarNode(:c)
+            ]), [:a, :c])
+        @test HerbCore.issame(ordered1, ordered2) == true
+        @test HerbCore.issame(ordered1, ordered3) == false
+
+    end
 end

--- a/test/test_unique.jl
+++ b/test/test_unique.jl
@@ -132,6 +132,12 @@
 
     @testset "update_rule_indices!" begin
         @testset "interface without grammar" begin
+            grammar = @csgrammar begin
+                Number = x | 1
+                Number = Number + Number
+                Number = Number - Number
+            end
+            addconstraint!(grammar, Unique(1))
             c = Unique(1)
             n_rules = 5
             mapping = Dict(1 => 5, 2 => 6)
@@ -160,14 +166,11 @@
         end
     end
     @testset "is_domain_valid" begin
-        grammar = @csgrammar begin
-            Int = 1
-            Int = x
-            Int = -Int
-            Int = Int + Int
-            Int = Int * Int
-        end
         @test HerbCore.is_domain_valid(Unique(8), grammar) == false
         @test HerbCore.is_domain_valid(Unique(3), grammar) == true
+    end
+    @testset "issame" begin
+        @test HerbCore.issame(Unique(2), Unique(2)) == true
+        @test HerbCore.issame(Unique(17), Unique(2)) == false
     end
 end

--- a/test/test_varnode.jl
+++ b/test/test_varnode.jl
@@ -25,4 +25,8 @@
     @testset "is_domain_valid" begin
         @test HerbCore.is_domain_valid(VarNode(:a), 99) == true
     end
+    @testset "issame" begin
+        @test HerbCore.issame(VarNode(:a), VarNode(:a)) == true
+        @test HerbCore.issame(VarNode(:a), VarNode(:z)) == false
+    end
 end


### PR DESCRIPTION
## Changes

Interface `issame()` for
- rule nodes (`VarNode`, `DomainRuleNode`)
- grammar constraints

Tests for `addconstraint!` with duplicate constraints.

## Issues

Partly addresses Herb-AI/HerbGrammar.jl#116

Closes #98. 