### PR TITLE
Release bump to `DataStructures@0.19`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbConstraints"
 uuid = "1fa96474-3206-4513-b4fa-23913f296dfc"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>"]
-version = "0.4.7"
+version = "0.4.8"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"


### PR DESCRIPTION
Both #101 and #102 bumped the version to `v0.4.7`, meaning we could only release #101. Bumped to `v0.4.8` so we can release #102 as well 😄 