### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbConstraints"
 uuid = "1fa96474-3206-4513-b4fa-23913f296dfc"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>"]
-version = "0.5.0"
+version = "1.0.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -12,8 +12,8 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
 DataStructures = "0.19"
-HerbCore = "^0.3.0"
-HerbGrammar = "0.6"
+HerbCore = "1"
+HerbGrammar = "1"
 MLStyle = "^0.4.17"
 TimerOutputs = "0.5.28"
 julia = "1.10"

--- a/src/solver/generic_solver/generic_solver.jl
+++ b/src/solver/generic_solver/generic_solver.jl
@@ -224,7 +224,7 @@ end
 
 
 """
-    function get_max_depth(solver::GenericSolver)::SolverState
+    function get_max_size(solver::GenericSolver)::SolverState
 
 Get the maximum number of [`AbstractRuleNode`](@ref)s allowed inside the tree.
 """


### PR DESCRIPTION
- updated `Herb*` packages dependencies to `"1"`
- fixed typo in documentation of `get_max_size`. 
- bumped version of `HerbConstraints` to `1.0.0`.