### PR TITLE
Constraint monotonicity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HerbConstraints"
 uuid = "1fa96474-3206-4513-b4fa-23913f296dfc"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Jaap de Jong <jaapdejong15@gmail.com>"]
 
 [deps]
@@ -21,7 +21,7 @@ ASPExt = "Clingo_jll"
 Clingo_jll = "5.7.1"
 DataStructures = "0.19"
 DocStringExtensions = "0.9.5"
-HerbCore = "1"
+HerbCore = "1.1"
 HerbGrammar = "1.1"
 MLStyle = "^0.4.17"
 TimerOutputs = "0.5.28"

--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -163,6 +163,6 @@ export
     StateHole,
     freeze_state,
     update_rule_indices!,
-    issame, ASPSolver
+    ASPSolver
 
 end # module HerbConstraints

--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -43,22 +43,6 @@ function get_priority(::AbstractLocalConstraint)
     return 0
 end
 
-"""
-    ismonotone(c::AbstractConstraint)::Bool
-
-Returns `true` if the constraint is monotone: if it is satisfied for a partial tree,
-it remains satisfied for all completions of that tree. Defaults to `false`.
-"""
-ismonotone(::AbstractConstraint) = false
-
-"""
-    isantimonotone(c::AbstractConstraint)::Bool
-
-Returns `true` if the constraint is anti-monotone: if it is violated for a partial tree,
-it remains violated for all completions of that tree. Defaults to `false`.
-"""
-isantimonotone(::AbstractConstraint) = false
-
 include("varnode.jl")
 include("domainrulenode.jl")
 
@@ -171,10 +155,6 @@ export
     set_value!,
     increment!,
     decrement!,
-
-    #monotonicity
-    ismonotone,
-    isantimonotone,
 
     #uniform solver
     UniformSolver,

--- a/src/domainrulenode.jl
+++ b/src/domainrulenode.jl
@@ -94,9 +94,9 @@ function HerbCore.is_domain_valid(node::DomainRuleNode, n_rules::Integer)
     all(child -> HerbCore.is_domain_valid(child, n_rules), get_children(node))
 end
 
-function HerbCore.issame(A::DomainRuleNode, B::DomainRuleNode)
+function Base.:(==)(A::DomainRuleNode, B::DomainRuleNode)
 
-    A.domain == B.domain && length(A.children) == length(B.children) && all(HerbCore.issame(a, b) for (a, b) in zip(A.children, B.children))
+    A.domain == B.domain && length(A.children) == length(B.children) && all(HerbCore.isequal(a, b) for (a, b) in zip(A.children, B.children))
 
 end
 

--- a/src/grammarconstraints/contains.jl
+++ b/src/grammarconstraints/contains.jl
@@ -105,6 +105,4 @@ end
 HerbCore.is_domain_valid(c::Contains, n_rules::Integer) = c.rule <= n_rules
 HerbCore.is_domain_valid(c::Contains, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c, length(grammar.rules))
 
-HerbCore.issame(c1::Contains, c2::Contains) = c1 == c2
-
 HerbGrammar.is_constraint_valid(c::Contains, grammar::AbstractGrammar; allow_empty_children::Bool) = (c.rule <= length(grammar.rules)) && (c.rule >= 1)

--- a/src/grammarconstraints/contains.jl
+++ b/src/grammarconstraints/contains.jl
@@ -62,12 +62,12 @@ end
 """
     update_rule_indices!(c::Contains, n_rules::Integer, mapping::AbstractDict{<:Integer,<:Integer}, constraints::Vector{<:AbstractConstraint})
 
-Updates the `Contains` constraint to reflect grammar changes by replacing it with a new
+Updates the `Contains` constraint to reflect grammar changes by replacing it with a new 
 `Contains` constraint using the mapped rule index.
 
 # Arguments
 - `c`: The `Contains` constraint to be updated
-- `n_rules`: The new number of rules in the grammar
+- `n_rules`: The new number of rules in the grammar  
 - `mapping`: Dictionary mapping old rule indices to new rule indices
 - `constraints`: Vector of grammar constraints containing the constraint to update
 """
@@ -88,12 +88,12 @@ end
 """
     update_rule_indices!(c::Contains, grammar::AbstractGrammar, mapping::AbstractDict{<:Integer,<:Integer})
 
-Updates the `Contains` constraint to reflect grammar changes by replacing it with a new
+Updates the `Contains` constraint to reflect grammar changes by replacing it with a new 
 `Contains` constraint using the mapped rule index.
 
 # Arguments
 - `c`: The `Contains` constraint to be updated
-- `grammar`: The grammar that changed
+- `grammar`: The grammar that changed  
 - `mapping`: Dictionary mapping old rule indices to new rule indices
 """
 function HerbCore.update_rule_indices!(c::Contains,
@@ -104,14 +104,5 @@ end
 
 HerbCore.is_domain_valid(c::Contains, n_rules::Integer) = c.rule <= n_rules
 HerbCore.is_domain_valid(c::Contains, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c, length(grammar.rules))
-
-"""
-    ismonotone(::Contains)::Bool
-
-Returns `true`. A [`Contains`](@ref) constraint is monotone: once the required rule is present
-in a partial tree, filling holes can only add nodes, never remove existing ones, so the
-constraint remains satisfied in all completions.
-"""
-ismonotone(::Contains) = true
 
 HerbGrammar.is_constraint_valid(c::Contains, grammar::AbstractGrammar; allow_empty_children::Bool) = (c.rule <= length(grammar.rules)) && (c.rule >= 1)

--- a/src/grammarconstraints/contains_subtree.jl
+++ b/src/grammarconstraints/contains_subtree.jl
@@ -102,7 +102,7 @@ end
 HerbCore.is_domain_valid(c::ContainsSubtree, n_rules::Integer) = HerbCore.is_domain_valid(c.tree, n_rules)
 HerbCore.is_domain_valid(c::ContainsSubtree, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c.tree, length(grammar.rules))
 
-HerbCore.issame(c1::ContainsSubtree, c2::ContainsSubtree) = HerbCore.issame(c1.tree, c2.tree)
+Base.:(==)(c1::ContainsSubtree, c2::ContainsSubtree) = (c1.tree == c2.tree)
 
 function HerbGrammar.is_constraint_valid(c::ContainsSubtree, grammar::AbstractGrammar; allow_empty_children::Bool)
     return HerbGrammar.is_tree_valid(c.tree, grammar; allow_empty_children=allow_empty_children)

--- a/src/grammarconstraints/contains_subtree.jl
+++ b/src/grammarconstraints/contains_subtree.jl
@@ -102,19 +102,7 @@ end
 HerbCore.is_domain_valid(c::ContainsSubtree, n_rules::Integer) = HerbCore.is_domain_valid(c.tree, n_rules)
 HerbCore.is_domain_valid(c::ContainsSubtree, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c.tree, length(grammar.rules))
 
-
-"""
-    ismonotone(::ContainsSubtree)::Bool
-
-Returns `true`. A [`ContainsSubtree`](@ref) constraint is monotone: once the required subtree is
-present in a partial tree, filling holes can only add nodes, never remove existing ones, so the
-constraint remains satisfied in all completions.
-"""
-ismonotone(::ContainsSubtree) = true
-
-
 Base.:(==)(c1::ContainsSubtree, c2::ContainsSubtree) = (c1.tree == c2.tree)
-
 
 function HerbGrammar.is_constraint_valid(c::ContainsSubtree, grammar::AbstractGrammar; allow_empty_children::Bool)
     return HerbGrammar.is_tree_valid(c.tree, grammar; allow_empty_children=allow_empty_children)

--- a/src/grammarconstraints/forbidden.jl
+++ b/src/grammarconstraints/forbidden.jl
@@ -2,20 +2,20 @@
     Forbidden <: AbstractGrammarConstraint
 
 This [`AbstractGrammarConstraint`] forbids any subtree that matches the pattern given by `tree` to be generated.
-A pattern is a tree of [`AbstractRuleNode`](@ref)s.
+A pattern is a tree of [`AbstractRuleNode`](@ref)s. 
 
 # Example
 
-A node in the tree can be of any type `<:AbstractRuleNode`. For example, a [`RuleNode`](@ref), which contains a rule index corresponding to the
+A node in the tree can be of any type `<:AbstractRuleNode`. For example, a [`RuleNode`](@ref), which contains a rule index corresponding to the 
 rule index in the [`AbstractGrammar`](@ref) and the appropriate number of children, or a [`VarNode`](@ref), which contains a single identifier symbol.
 
 Let's consider the tree `1(a, 2(b, 3(c, 4))))`:
 
 - `Forbidden(RuleNode(3, [RuleNode(5), RuleNode(4)]))` forbids `c` to be filled with `5`.
-- `Forbidden(RuleNode(3, [VarNode(:v), RuleNode(4)]))` forbids `c` to be filled, since a [`VarNode`] can
-    match any rule, thus making the match attempt successful for the entire domain of `c`.
+- `Forbidden(RuleNode(3, [VarNode(:v), RuleNode(4)]))` forbids `c` to be filled, since a [`VarNode`] can 
+    match any rule, thus making the match attempt successful for the entire domain of `c`. 
     Therefore, this tree invalid.
-- `Forbidden(RuleNode(3, [VarNode(:v), VarNode(:v)]))` forbids `c` to be filled with `4`, since that would
+- `Forbidden(RuleNode(3, [VarNode(:v), VarNode(:v)]))` forbids `c` to be filled with `4`, since that would 
     make both assignments to `v` equal, which causes a successful match.
 
 A [`VarNode`](@ref) can match any subtree, but if there are multiple instances of the same
@@ -96,7 +96,7 @@ Updates the `Forbidden` constraint to reflect grammar changes by calling `HerbCo
 
 # Arguments
 - `c`: The `Forbidden` constraint to be updated
-- `n_rules`: The new number of rules in the grammar
+- `n_rules`: The new number of rules in the grammar  
 - `mapping`: Dictionary mapping old rule indices to new rule indices
 """
 function HerbCore.update_rule_indices!(
@@ -129,18 +129,7 @@ end
 HerbCore.is_domain_valid(c::Forbidden, n_rules::Integer) = HerbCore.is_domain_valid(c.tree, n_rules)
 HerbCore.is_domain_valid(c::Forbidden, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c.tree, length(grammar.rules))
 
-
-"""
-    isantimonotone(::Forbidden)::Bool
-
-Returns `true`. A [`Forbidden`](@ref) constraint is anti-monotone: if the forbidden pattern is
-present in a partial tree, it cannot be removed by filling holes, so the violation persists in
-all completions.
-"""
-isantimonotone(::Forbidden) = true
-
 Base.:(==)(c1::Forbidden, c2::Forbidden) = (c1.tree == c2.tree)
-
 
 function HerbGrammar.is_constraint_valid(c::Forbidden, grammar::AbstractGrammar; allow_empty_children::Bool)
     return HerbGrammar.is_tree_valid(c.tree, grammar; allow_empty_children=allow_empty_children)

--- a/src/grammarconstraints/forbidden.jl
+++ b/src/grammarconstraints/forbidden.jl
@@ -129,7 +129,7 @@ end
 HerbCore.is_domain_valid(c::Forbidden, n_rules::Integer) = HerbCore.is_domain_valid(c.tree, n_rules)
 HerbCore.is_domain_valid(c::Forbidden, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c.tree, length(grammar.rules))
 
-HerbCore.issame(c1::Forbidden, c2::Forbidden) = HerbCore.issame(c1.tree, c2.tree)
+Base.:(==)(c1::Forbidden, c2::Forbidden) = (c1.tree == c2.tree)
 
 function HerbGrammar.is_constraint_valid(c::Forbidden, grammar::AbstractGrammar; allow_empty_children::Bool)
     return HerbGrammar.is_tree_valid(c.tree, grammar; allow_empty_children=allow_empty_children)

--- a/src/grammarconstraints/forbidden_sequence.jl
+++ b/src/grammarconstraints/forbidden_sequence.jl
@@ -123,7 +123,7 @@ Errors if rule indices exceeds number of grammar rules.
 
 # Arguments
 - `c`: The `ForbiddenSequence` constraint to be updated
-- `n_rules`: The new number of rules in the grammar
+- `n_rules`: The new number of rules in the grammar  
 - `mapping`: Dictionary mapping old rule indices to new rule indices
 """
 function HerbCore.update_rule_indices!(
@@ -160,17 +160,7 @@ end
 HerbCore.is_domain_valid(c::ForbiddenSequence, n_rules::Integer) = all(i -> i <= n_rules, c.sequence) && all(i -> i <= n_rules, c.ignore_if)
 HerbCore.is_domain_valid(c::ForbiddenSequence, grammar::ContextSensitiveGrammar) = HerbCore.is_domain_valid(c, length(grammar.rules))
 
-"""
-    isantimonotone(::ForbiddenSequence)::Bool
-
-Returns `true`. A [`ForbiddenSequence`](@ref) constraint is anti-monotone: if the forbidden
-vertical sequence of rules is already present in a partial tree, no completion can remove those
-nodes, so the violation persists in all completions.
-"""
-isantimonotone(::ForbiddenSequence) = true
-
 Base.:(==)(c1::ForbiddenSequence, c2::ForbiddenSequence) = (c1.sequence == c2.sequence) && (c1.ignore_if == c2.ignore_if)
-
 
 function HerbGrammar.is_constraint_valid(c::ForbiddenSequence, grammar::AbstractGrammar; allow_empty_children::Bool)
     n_rules = length(grammar.rules)

--- a/src/grammarconstraints/forbidden_sequence.jl
+++ b/src/grammarconstraints/forbidden_sequence.jl
@@ -160,7 +160,7 @@ end
 HerbCore.is_domain_valid(c::ForbiddenSequence, n_rules::Integer) = all(i -> i <= n_rules, c.sequence) && all(i -> i <= n_rules, c.ignore_if)
 HerbCore.is_domain_valid(c::ForbiddenSequence, grammar::ContextSensitiveGrammar) = HerbCore.is_domain_valid(c, length(grammar.rules))
 
-HerbCore.issame(c1::ForbiddenSequence, c2::ForbiddenSequence) = (c1.sequence == c2.sequence) && (c1.ignore_if == c2.ignore_if)
+Base.:(==)(c1::ForbiddenSequence, c2::ForbiddenSequence) = (c1.sequence == c2.sequence) && (c1.ignore_if == c2.ignore_if)
 
 function HerbGrammar.is_constraint_valid(c::ForbiddenSequence, grammar::AbstractGrammar; allow_empty_children::Bool)
     n_rules = length(grammar.rules)

--- a/src/grammarconstraints/ordered.jl
+++ b/src/grammarconstraints/ordered.jl
@@ -134,7 +134,7 @@ end
 HerbCore.is_domain_valid(c::Ordered, n_rules::Integer) = HerbCore.is_domain_valid(c.tree, n_rules)
 HerbCore.is_domain_valid(c::Ordered, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c.tree, length(grammar.rules))
 
-HerbCore.issame(c1::Ordered, c2::Ordered) = HerbCore.issame(c1.tree, c2.tree) && c1.order == c2.order
+Base.:(==)(c1::Ordered, c2::Ordered) = (c1.tree == c2.tree) && (c1.order == c2.order)
 
 function HerbGrammar.is_constraint_valid(c::Ordered, grammar::AbstractGrammar; allow_empty_children::Bool)
     return HerbGrammar.is_tree_valid(c.tree, grammar; allow_empty_children=allow_empty_children)

--- a/src/grammarconstraints/ordered.jl
+++ b/src/grammarconstraints/ordered.jl
@@ -1,27 +1,27 @@
 """
     Ordered <: AbstractGrammarConstraint
 
-A [`AbstractGrammarConstraint`](@ref) that enforces a specific order in [`MatchVar`](@ref)
+A [`AbstractGrammarConstraint`](@ref) that enforces a specific order in [`MatchVar`](@ref) 
 assignments in the pattern defined by `tree`.
-Nodes in the pattern can either be a [`RuleNode`](@ref), which contains a rule index corresponding to the
+Nodes in the pattern can either be a [`RuleNode`](@ref), which contains a rule index corresponding to the 
 rule index in the [`AbstractGrammar`](@ref) and the appropriate number of children.
 It can also contain a [`VarNode`](@ref), which contains a single identifier symbol.
-A [`VarNode`](@ref) can match any subtree.
+A [`VarNode`](@ref) can match any subtree. 
 If there are multiple instances of the same variable in the pattern, the matched subtrees must be identical.
 
-The `order` defines an order between the variable assignments.
-For example, if the order is `[x, y]`, the constraint will require
+The `order` defines an order between the variable assignments. 
+For example, if the order is `[x, y]`, the constraint will require 
 the assignment to `x` to be less than or equal to the assignment to `y`.
-The order is recursively defined by [`RuleNode`](@ref) indices.
+The order is recursively defined by [`RuleNode`](@ref) indices. 
 For more information, see [`Base.isless(rn₁::AbstractRuleNode, rn₂::AbstractRuleNode)`](@ref).
 
 For example, consider the tree `1(a, 2(b, 3(c, 4))))`:
 
-- `Ordered(RuleNode(3, [VarNode(:v), VarNode(:w)]), [:v, :w])` removes every rule
-    with an index of 5 or greater from the domain of `c`, since that would make the index of the
+- `Ordered(RuleNode(3, [VarNode(:v), VarNode(:w)]), [:v, :w])` removes every rule 
+    with an index of 5 or greater from the domain of `c`, since that would make the index of the 
     assignment to `v` greater than the index of the assignment to `w`, violating the order.
-- `Ordered(RuleNode(3, [VarNode(:v), VarNode(:w)]), [:w, :v])` removes every rule
-    with an index of 4 or less from the domain of `c`, since that would make the index of the
+- `Ordered(RuleNode(3, [VarNode(:v), VarNode(:w)]), [:w, :v])` removes every rule 
+    with an index of 4 or less from the domain of `c`, since that would make the index of the 
     assignment to `v` less than the index of the assignment to `w`, violating the order.
 """
 struct Ordered <: AbstractGrammarConstraint
@@ -101,7 +101,7 @@ Updates the `Ordered` constraint to reflect grammar changes by calling `HerbCore
 
 # Arguments
 - `c`: The `Ordered` constraint to be updated
-- `n_rules`: The new number of rules in the grammar
+- `n_rules`: The new number of rules in the grammar  
 - `mapping`: Dictionary mapping old rule indices to new rule indices
 """
 function HerbCore.update_rule_indices!(
@@ -133,15 +133,6 @@ end
 
 HerbCore.is_domain_valid(c::Ordered, n_rules::Integer) = HerbCore.is_domain_valid(c.tree, n_rules)
 HerbCore.is_domain_valid(c::Ordered, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c.tree, length(grammar.rules))
-
-"""
-    isantimonotone(::Ordered)::Bool
-
-Returns `true`. An [`Ordered`](@ref) constraint is anti-monotone: once the variable assignments
-are fixed (no holes remain in the matched pattern) and the ordering is violated, filling further
-holes elsewhere in the tree cannot undo that violation.
-"""
-isantimonotone(::Ordered) = true
 
 Base.:(==)(c1::Ordered, c2::Ordered) = (c1.tree == c2.tree) && (c1.order == c2.order)
 

--- a/src/grammarconstraints/unique.jl
+++ b/src/grammarconstraints/unique.jl
@@ -119,6 +119,5 @@ end
 HerbCore.is_domain_valid(c::Unique, n_rules::Integer) = c.rule <= n_rules
 HerbCore.is_domain_valid(c::Unique, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c, length(grammar.rules))
 
-HerbCore.issame(c1::Unique, c2::Unique) = c1 == c2
 
 HerbGrammar.is_constraint_valid(c::Unique, grammar::AbstractGrammar; allow_empty_children::Bool) = (c.rule <= length(grammar.rules)) && (c.rule >= 1)

--- a/src/grammarconstraints/unique.jl
+++ b/src/grammarconstraints/unique.jl
@@ -76,12 +76,12 @@ end
     mapping::AbstractDict{<:Integer,<:Integer},
     constraints::Vector{<:AbstractConstraint})
 
-Updates the `Unique` constraint to reflect grammar changes by replacing it with a new
+Updates the `Unique` constraint to reflect grammar changes by replacing it with a new 
 `Unique` constraint using the mapped rule index. Errors if rule index exceeds new `n_rules`.
 
 # Arguments
 - `c`: The `Unique` constraint to be updated
-- `n_rules`: The new number of rules in the grammar
+- `n_rules`: The new number of rules in the grammar  
 - `mapping`: Dictionary mapping old rule indices to new rule indices
 - `constraints`: Vector of grammar constraints containing the constraint to update
 """
@@ -102,7 +102,7 @@ end
     grammar::AbstractGrammar,
     mapping::AbstractDict{<:Integer,<:Integer})
 
-Updates the `Unique` constraint to reflect grammar changes by replacing it with a new
+Updates the `Unique` constraint to reflect grammar changes by replacing it with a new 
 `Unique` constraint using the mapped rule index.Errors if rule index exceeds number of grammar rules.
 
 # Arguments
@@ -118,15 +118,6 @@ end
 
 HerbCore.is_domain_valid(c::Unique, n_rules::Integer) = c.rule <= n_rules
 HerbCore.is_domain_valid(c::Unique, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c, length(grammar.rules))
-
-"""
-    isantimonotone(::Unique)::Bool
-
-Returns `true`. A [`Unique`](@ref) constraint is anti-monotone: if the required rule already
-appears more than once in a partial tree, filling holes can only add further nodes, never remove
-existing ones, so the violation persists in all completions.
-"""
-isantimonotone(::Unique) = true
 
 
 HerbGrammar.is_constraint_valid(c::Unique, grammar::AbstractGrammar; allow_empty_children::Bool) = (c.rule <= length(grammar.rules)) && (c.rule >= 1)

--- a/src/localconstraints/local_contains.jl
+++ b/src/localconstraints/local_contains.jl
@@ -10,15 +10,6 @@ struct LocalContains <: AbstractLocalConstraint
 end
 
 """
-    ismonotone(::LocalContains)::Bool
-
-Returns `true`. A [`LocalContains`](@ref) constraint is monotone: once the required rule is
-present at or below the constrained path, filling holes can only add nodes, never remove
-existing ones, so the constraint remains satisfied in all completions.
-"""
-ismonotone(::LocalContains) = true
-
-"""
     function propagate!(solver::Solver, c::LocalContains)
 
 Enforce that the `rule` appears at or below the `path` at least once.

--- a/src/localconstraints/local_contains_subtree.jl
+++ b/src/localconstraints/local_contains_subtree.jl
@@ -16,15 +16,6 @@ mutable struct LocalContainsSubtree <: AbstractLocalConstraint
 end
 
 """
-    ismonotone(::LocalContainsSubtree)::Bool
-
-Returns `true`. A [`LocalContainsSubtree`](@ref) constraint is monotone: once the required
-subtree is present at or below the constrained path, filling holes can only add nodes, never
-remove existing ones, so the constraint remains satisfied in all completions.
-"""
-ismonotone(::LocalContainsSubtree) = true
-
-"""
     LocalContainsSubtree(path::Vector{Int}, tree::AbstractRuleNode)
 
 Enforces that a given `tree` appears at or below the given `path` at least once.

--- a/src/localconstraints/local_forbidden.jl
+++ b/src/localconstraints/local_forbidden.jl
@@ -12,15 +12,6 @@ struct LocalForbidden <: AbstractLocalConstraint
 end
 
 """
-    isantimonotone(::LocalForbidden)::Bool
-
-Returns `true`. A [`LocalForbidden`](@ref) constraint is anti-monotone: if the forbidden pattern
-is present at the constrained location in a partial tree, no completion can remove those nodes,
-so the violation persists in all completions.
-"""
-isantimonotone(::LocalForbidden) = true
-
-"""
     function propagate!(solver::Solver, c::LocalForbidden)
 
 Enforce that the forbidden `tree` does not occur at the `path`.

--- a/src/localconstraints/local_forbidden_sequence.jl
+++ b/src/localconstraints/local_forbidden_sequence.jl
@@ -11,15 +11,6 @@ struct LocalForbiddenSequence <: AbstractLocalConstraint
 end
 
 """
-    isantimonotone(::LocalForbiddenSequence)::Bool
-
-Returns `true`. A [`LocalForbiddenSequence`](@ref) constraint is anti-monotone: if the forbidden
-vertical sequence of rules is already present along the constrained path, no completion can
-remove those nodes, so the violation persists in all completions.
-"""
-isantimonotone(::LocalForbiddenSequence) = true
-
-"""
     shouldschedule(::Solver, constraint::LocalForbiddenSequence, path::Vector{Int})::Bool
 
 Return true iff the manipulation happened at or above the constraint path.

--- a/src/localconstraints/local_ordered.jl
+++ b/src/localconstraints/local_ordered.jl
@@ -10,15 +10,6 @@ mutable struct LocalOrdered <: AbstractLocalConstraint
 end
 
 """
-    isantimonotone(::LocalOrdered)::Bool
-
-Returns `true`. A [`LocalOrdered`](@ref) constraint is anti-monotone: once the variable
-assignments are fixed (no holes remain in the matched pattern) and the ordering is violated,
-filling further holes elsewhere in the tree cannot undo that violation.
-"""
-isantimonotone(::LocalOrdered) = true
-
-"""
     function propagate!(solver::Solver, c::LocalOrdered)
 
 Enforce that the [`VarNode`](@ref)s in the `tree` are in the specified `order`.

--- a/src/localconstraints/local_unique.jl
+++ b/src/localconstraints/local_unique.jl
@@ -11,15 +11,6 @@ struct LocalUnique <: AbstractLocalConstraint
     holes::Vector{AbstractHole}
 end
 
-"""
-    isantimonotone(::LocalUnique)::Bool
-
-Returns `true`. A [`LocalUnique`](@ref) constraint is anti-monotone: if the required rule
-already appears more than once at or below the constrained path, filling holes can only add
-further nodes, never remove existing ones, so the violation persists in all completions.
-"""
-isantimonotone(::LocalUnique) = true
-
 LocalUnique(path::Vector{Int}, rule::Int) = LocalUnique(path, rule, Vector{AbstractHole}())
 
 """

--- a/src/varnode.jl
+++ b/src/varnode.jl
@@ -61,8 +61,6 @@ end
 # Always return `true` (interface only)
 HerbCore.is_domain_valid(node::VarNode, n_rules::Integer) = true
 
-HerbCore.issame(A::VarNode, B::VarNode) = A.name == B.name
-
 HerbGrammar.is_tree_valid(vn::VarNode, grammar::AbstractGrammar; allow_empty_children::Bool)::Bool = true
 
 HerbGrammar.is_tree_valid(vn::VarNode, grammar::AbstractGrammar, expected_type::Symbol; allow_empty_children::Bool)::Bool = true

--- a/test/asp_solver_test.jl
+++ b/test/asp_solver_test.jl
@@ -584,7 +584,7 @@
             :- node(X1,4),child(X1,1,X2),child(X1,2,X3),child(X1,3,X4),not is_smaller(X4,X2).
 
             """
-            @test expected_asp == asp_tree
+            @test asp_tree == expected_asp
 
             solver = @test_nowarn ASPSolver(g, tree)
             @test 10 == length(solver.solutions)

--- a/test/contains_subtree_test.jl
+++ b/test/contains_subtree_test.jl
@@ -359,7 +359,7 @@
         )
         @test HerbCore.is_domain_valid(contains_subtree, grammar) == true
     end
-    @testset "issame" begin
+    @testset "isequal" begin
         tree1 = UniformHole(BitVector((0, 0, 1, 1)), [
             RuleNode(1),
             RuleNode(4, [
@@ -374,7 +374,7 @@
                 UniformHole(BitVector((1, 1, 1, 0)), [])
             ])
         ])
-        @test HerbCore.issame(ContainsSubtree(tree1), ContainsSubtree(tree1)) == true
-        @test HerbCore.issame(ContainsSubtree(tree1), ContainsSubtree(tree2)) == false
+        @test ContainsSubtree(tree1) == ContainsSubtree(tree1)
+        @test ContainsSubtree(tree1) != ContainsSubtree(tree2)
     end
 end

--- a/test/contains_test.jl
+++ b/test/contains_test.jl
@@ -80,8 +80,8 @@
         @test HerbCore.is_domain_valid(Contains(8), grammar) == false
         @test HerbCore.is_domain_valid(Contains(3), grammar) == true
     end
-    @testset "issame" begin
-        @test HerbCore.issame(Contains(12), Contains(12)) == true
-        @test HerbCore.issame(Contains(12), Contains(12222)) == false
+    @testset "isequal" begin
+        @test Contains(12) == Contains(12)
+        @test Contains(12) != Contains(12222)
     end
 end

--- a/test/domainrulenode_test.jl
+++ b/test/domainrulenode_test.jl
@@ -39,14 +39,12 @@
         @test HerbCore.is_domain_valid(node1, n_rules) == false
         @test HerbCore.is_domain_valid(node2, n_rules) == true
     end
-    @testset "issame" begin
-
+    @testset "isequal" begin
         node1 = DomainRuleNode(BitVector((1, 0)), [DomainRuleNode(BitVector((1, 1))), DomainRuleNode(BitVector((0, 1)))])
         node2 = DomainRuleNode(BitVector((1, 0)), [DomainRuleNode(BitVector((1, 1))), DomainRuleNode(BitVector((0, 1)))])
         node3 = DomainRuleNode(BitVector((1, 0)))
-        @test HerbCore.issame(node1, node2) == true
-        @test HerbCore.issame(node2, node3) == false
-
+        @test node1 == node2
+        @test node1 != node3
     end
     @testset "error on number of children mismatch with N children in rules in domain" begin
         g = @csgrammar begin

--- a/test/forbidden_sequence_test.jl
+++ b/test/forbidden_sequence_test.jl
@@ -348,13 +348,13 @@
         constraint2 = ForbiddenSequence([1, 2, 3], ignore_if=[4, 5])
         @test HerbCore.is_domain_valid(constraint2, grammar) == true
     end
-    @testset "issame" begin
+    @testset "isequal" begin
         constraint1 = ForbiddenSequence([1, 2, 3], ignore_if=[4, 5, 6, 7, 8])
         constraint2 = ForbiddenSequence([1, 2, 3], ignore_if=[4, 5, 6, 7, 8])
         constraint3 = ForbiddenSequence([1, 2, 3], ignore_if=[4, 5, 6])
         constraint4 = ForbiddenSequence([1, 2, 5], ignore_if=[4, 5, 6])
-        @test HerbCore.issame(constraint1, constraint2) == true
-        @test HerbCore.issame(constraint1, constraint3) == false
-        @test HerbCore.issame(constraint3, constraint4) == false
+        @test constraint1 == constraint2
+        @test constraint1 != constraint3
+        @test constraint3 != constraint4
     end
 end

--- a/test/forbidden_test.jl
+++ b/test/forbidden_test.jl
@@ -117,7 +117,7 @@
         @test HerbCore.is_domain_valid(forbidden1, grammar) == false
         @test HerbCore.is_domain_valid(forbidden2, grammar) == true
     end
-    @testset "issame" begin
+    @testset "isequal" begin
         forbidden1 = Forbidden(RuleNode(4, [
             VarNode(:a),
             VarNode(:a)
@@ -130,7 +130,7 @@
             VarNode(:b),
             VarNode(:b)
         ]))
-        @test HerbCore.issame(forbidden1, forbidden2) == true
-        @test HerbCore.issame(forbidden1, forbidden3) == false
+        @test forbidden1 == forbidden2
+        @test forbidden1 != forbidden3
     end
 end

--- a/test/grammarconstraints_test.jl
+++ b/test/grammarconstraints_test.jl
@@ -113,7 +113,8 @@
 
 
     end
-    @testset "issame" begin
-        @test HerbCore.issame(Contains(1), Unique(1)) == false
+    @testset "isequal" begin
+        @test Contains(1) == Contains(1)
+        @test Contains(1) != Unique(1)
     end
 end

--- a/test/ordered_test.jl
+++ b/test/ordered_test.jl
@@ -227,7 +227,7 @@
         @test HerbCore.is_domain_valid(ordered2, grammar) == false
 
     end
-    @testset "issame" begin
+    @testset "isequal" begin
         ordered1 = Ordered(RuleNode(4, [
                 VarNode(:a),
                 VarNode(:b)
@@ -240,8 +240,8 @@
                 VarNode(:a),
                 VarNode(:c)
             ]), [:a, :c])
-        @test HerbCore.issame(ordered1, ordered2) == true
-        @test HerbCore.issame(ordered1, ordered3) == false
+        @test ordered1 == ordered2
+        @test ordered1 != ordered3
 
     end
 end

--- a/test/unique_test.jl
+++ b/test/unique_test.jl
@@ -171,8 +171,8 @@
         @test HerbCore.is_domain_valid(Unique(8), grammar) == false
         @test HerbCore.is_domain_valid(Unique(3), grammar) == true
     end
-    @testset "issame" begin
-        @test HerbCore.issame(Unique(2), Unique(2)) == true
-        @test HerbCore.issame(Unique(17), Unique(2)) == false
+    @testset "isequal" begin
+        @test Unique(2) == Unique(2)
+        @test Unique(17) != Unique(2)
     end
 end

--- a/test/varnode_test.jl
+++ b/test/varnode_test.jl
@@ -26,8 +26,8 @@
     @testset "is_domain_valid" begin
         @test HerbCore.is_domain_valid(VarNode(:a), 99) == true
     end
-    @testset "issame" begin
-        @test HerbCore.issame(VarNode(:a), VarNode(:a)) == true
-        @test HerbCore.issame(VarNode(:a), VarNode(:z)) == false
+    @testset "isequal" begin
+        @test VarNode(:a) == VarNode(:a)
+        @test VarNode(:a) != VarNode(:z)
     end
 end


### PR DESCRIPTION
from @sebdumancic https://github.com/Herb-AI/HerbConstraints.jl/pull/126#issuecomment-4286977880:

> Two functions introduced to src/HerbConstraints.jl, both defaulting to false:
> 
>   - `ismonotone(c)` — if a partial tree satisfies the constraint, all completions also satisfy it.
>   - `isantimonotone(c)` — if a partial tree violates the constraint, all completions also violate it.
> 
> 
>   **Classification of the built-in constraints**
> 
> _Contains_:
>  - is monotone: yes
>  - is anti-monotone: false
>  - rationale: Once the required rule appears, completions can only add nodes, never remove them 
>  
> _ContainsSubtree_:
>  - is monotone: yes
>  - is anti-monotone: false
>  - rationale: Same reasoning as contains
>   
> 
> _Forbidden_:
>  - is monotone: false
>  - is anti-monotone: true
>  - rationale:  Once the forbidden pattern is matched, no completion can un-match it
> 
> 
> _ForbiddenSequence_:
>  - is monotone: false
>  - is anti-monotone: true
>  - rationale:  A forbidden vertical sequence already in the tree cannot be  undone by filling holes 
> 
> 
> _Ordered_:
>  - is monotone: false
>  - is anti-monotone: true
>  - rationale:  Once variable assignments are fixed and order is violated, further hole-filling elsewhere can't undo the violation
> 
> 
> _Unique_:
>  - is monotone: false
>  - is anti-monotone: true
>  - rationale:  A rule appearing more than once in a partial tree can only appear more often in completions  
> 
> 
>   **Local constraint counterparts**
> 
>   The same overrides were added for all six local constraint types (LocalContains, LocalContainsSubtree, LocalForbidden, LocalForbiddenSequence, LocalOrdered, LocalUnique) mirroring the grammar-level classifications.