### PR TITLE
Add (anti)monotonicity functions

### DIFF
--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -43,6 +43,22 @@ function get_priority(::AbstractLocalConstraint)
     return 0
 end
 
+"""
+    ismonotone(c::AbstractConstraint)::Bool
+
+Returns `true` if the constraint is monotone: if it is satisfied for a partial tree,
+it remains satisfied for all completions of that tree. Defaults to `false`.
+"""
+ismonotone(::AbstractConstraint) = false
+
+"""
+    isantimonotone(c::AbstractConstraint)::Bool
+
+Returns `true` if the constraint is anti-monotone: if it is violated for a partial tree,
+it remains violated for all completions of that tree. Defaults to `false`.
+"""
+isantimonotone(::AbstractConstraint) = false
+
 include("varnode.jl")
 include("domainrulenode.jl")
 
@@ -155,6 +171,10 @@ export
     set_value!,
     increment!,
     decrement!,
+
+    #monotonicity
+    ismonotone,
+    isantimonotone,
 
     #uniform solver
     UniformSolver,

--- a/src/HerbConstraints.jl
+++ b/src/HerbConstraints.jl
@@ -54,7 +54,7 @@ ismonotone(::AbstractConstraint) = false
 """
     isantimonotone(c::AbstractConstraint)::Bool
 
-Returns `true` if the constraint is anti-monotone: if it is violated for a partial tree,
+Returns `true` if the constraint is anti-monotone: if the constraint is violated for a partial tree,
 it remains violated for all completions of that tree. Defaults to `false`.
 """
 isantimonotone(::AbstractConstraint) = false

--- a/src/grammarconstraints/contains.jl
+++ b/src/grammarconstraints/contains.jl
@@ -105,4 +105,13 @@ end
 HerbCore.is_domain_valid(c::Contains, n_rules::Integer) = c.rule <= n_rules
 HerbCore.is_domain_valid(c::Contains, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c, length(grammar.rules))
 
+"""
+    ismonotone(::Contains)::Bool
+
+Returns `true`. A [`Contains`](@ref) constraint is monotone: once the required rule is present
+in a partial tree, filling holes can only add nodes, never remove existing ones, so the
+constraint remains satisfied in all completions.
+"""
+ismonotone(::Contains) = true
+
 HerbGrammar.is_constraint_valid(c::Contains, grammar::AbstractGrammar; allow_empty_children::Bool) = (c.rule <= length(grammar.rules)) && (c.rule >= 1)

--- a/src/grammarconstraints/contains_subtree.jl
+++ b/src/grammarconstraints/contains_subtree.jl
@@ -104,6 +104,15 @@ HerbCore.is_domain_valid(c::ContainsSubtree, grammar::AbstractGrammar) = HerbCor
 
 Base.:(==)(c1::ContainsSubtree, c2::ContainsSubtree) = (c1.tree == c2.tree)
 
+"""
+    ismonotone(::ContainsSubtree)::Bool
+
+Returns `true`. A [`ContainsSubtree`](@ref) constraint is monotone: once the required subtree is
+present in a partial tree, filling holes can only add nodes, never remove existing ones, so the
+constraint remains satisfied in all completions.
+"""
+ismonotone(::ContainsSubtree) = true
+
 function HerbGrammar.is_constraint_valid(c::ContainsSubtree, grammar::AbstractGrammar; allow_empty_children::Bool)
     return HerbGrammar.is_tree_valid(c.tree, grammar; allow_empty_children=allow_empty_children)
 end

--- a/src/grammarconstraints/forbidden.jl
+++ b/src/grammarconstraints/forbidden.jl
@@ -131,6 +131,15 @@ HerbCore.is_domain_valid(c::Forbidden, grammar::AbstractGrammar) = HerbCore.is_d
 
 Base.:(==)(c1::Forbidden, c2::Forbidden) = (c1.tree == c2.tree)
 
+"""
+    isantimonotone(::Forbidden)::Bool
+
+Returns `true`. A [`Forbidden`](@ref) constraint is anti-monotone: if the forbidden pattern is
+present in a partial tree, it cannot be removed by filling holes, so the violation persists in
+all completions.
+"""
+isantimonotone(::Forbidden) = true
+
 function HerbGrammar.is_constraint_valid(c::Forbidden, grammar::AbstractGrammar; allow_empty_children::Bool)
     return HerbGrammar.is_tree_valid(c.tree, grammar; allow_empty_children=allow_empty_children)
 end

--- a/src/grammarconstraints/forbidden_sequence.jl
+++ b/src/grammarconstraints/forbidden_sequence.jl
@@ -162,6 +162,15 @@ HerbCore.is_domain_valid(c::ForbiddenSequence, grammar::ContextSensitiveGrammar)
 
 Base.:(==)(c1::ForbiddenSequence, c2::ForbiddenSequence) = (c1.sequence == c2.sequence) && (c1.ignore_if == c2.ignore_if)
 
+"""
+    isantimonotone(::ForbiddenSequence)::Bool
+
+Returns `true`. A [`ForbiddenSequence`](@ref) constraint is anti-monotone: if the forbidden
+vertical sequence of rules is already present in a partial tree, no completion can remove those
+nodes, so the violation persists in all completions.
+"""
+isantimonotone(::ForbiddenSequence) = true
+
 function HerbGrammar.is_constraint_valid(c::ForbiddenSequence, grammar::AbstractGrammar; allow_empty_children::Bool)
     n_rules = length(grammar.rules)
     all(1 <= x <= n_rules for x in c.ignore_if) || return false

--- a/src/grammarconstraints/ordered.jl
+++ b/src/grammarconstraints/ordered.jl
@@ -136,6 +136,15 @@ HerbCore.is_domain_valid(c::Ordered, grammar::AbstractGrammar) = HerbCore.is_dom
 
 Base.:(==)(c1::Ordered, c2::Ordered) = (c1.tree == c2.tree) && (c1.order == c2.order)
 
+"""
+    isantimonotone(::Ordered)::Bool
+
+Returns `true`. An [`Ordered`](@ref) constraint is anti-monotone: once the variable assignments
+are fixed (no holes remain in the matched pattern) and the ordering is violated, filling further
+holes elsewhere in the tree cannot undo that violation.
+"""
+isantimonotone(::Ordered) = true
+
 function HerbGrammar.is_constraint_valid(c::Ordered, grammar::AbstractGrammar; allow_empty_children::Bool)
     return HerbGrammar.is_tree_valid(c.tree, grammar; allow_empty_children=allow_empty_children)
 end

--- a/src/grammarconstraints/unique.jl
+++ b/src/grammarconstraints/unique.jl
@@ -119,5 +119,14 @@ end
 HerbCore.is_domain_valid(c::Unique, n_rules::Integer) = c.rule <= n_rules
 HerbCore.is_domain_valid(c::Unique, grammar::AbstractGrammar) = HerbCore.is_domain_valid(c, length(grammar.rules))
 
+"""
+    isantimonotone(::Unique)::Bool
+
+Returns `true`. A [`Unique`](@ref) constraint is anti-monotone: if the required rule already
+appears more than once in a partial tree, filling holes can only add further nodes, never remove
+existing ones, so the violation persists in all completions.
+"""
+isantimonotone(::Unique) = true
+
 
 HerbGrammar.is_constraint_valid(c::Unique, grammar::AbstractGrammar; allow_empty_children::Bool) = (c.rule <= length(grammar.rules)) && (c.rule >= 1)

--- a/src/localconstraints/local_contains.jl
+++ b/src/localconstraints/local_contains.jl
@@ -10,6 +10,15 @@ struct LocalContains <: AbstractLocalConstraint
 end
 
 """
+    ismonotone(::LocalContains)::Bool
+
+Returns `true`. A [`LocalContains`](@ref) constraint is monotone: once the required rule is
+present at or below the constrained path, filling holes can only add nodes, never remove
+existing ones, so the constraint remains satisfied in all completions.
+"""
+ismonotone(::LocalContains) = true
+
+"""
     function propagate!(solver::Solver, c::LocalContains)
 
 Enforce that the `rule` appears at or below the `path` at least once.

--- a/src/localconstraints/local_contains_subtree.jl
+++ b/src/localconstraints/local_contains_subtree.jl
@@ -16,6 +16,15 @@ mutable struct LocalContainsSubtree <: AbstractLocalConstraint
 end
 
 """
+    ismonotone(::LocalContainsSubtree)::Bool
+
+Returns `true`. A [`LocalContainsSubtree`](@ref) constraint is monotone: once the required
+subtree is present at or below the constrained path, filling holes can only add nodes, never
+remove existing ones, so the constraint remains satisfied in all completions.
+"""
+ismonotone(::LocalContainsSubtree) = true
+
+"""
     LocalContainsSubtree(path::Vector{Int}, tree::AbstractRuleNode)
 
 Enforces that a given `tree` appears at or below the given `path` at least once.

--- a/src/localconstraints/local_forbidden.jl
+++ b/src/localconstraints/local_forbidden.jl
@@ -12,6 +12,15 @@ struct LocalForbidden <: AbstractLocalConstraint
 end
 
 """
+    isantimonotone(::LocalForbidden)::Bool
+
+Returns `true`. A [`LocalForbidden`](@ref) constraint is anti-monotone: if the forbidden pattern
+is present at the constrained location in a partial tree, no completion can remove those nodes,
+so the violation persists in all completions.
+"""
+isantimonotone(::LocalForbidden) = true
+
+"""
     function propagate!(solver::Solver, c::LocalForbidden)
 
 Enforce that the forbidden `tree` does not occur at the `path`.

--- a/src/localconstraints/local_forbidden_sequence.jl
+++ b/src/localconstraints/local_forbidden_sequence.jl
@@ -11,6 +11,15 @@ struct LocalForbiddenSequence <: AbstractLocalConstraint
 end
 
 """
+    isantimonotone(::LocalForbiddenSequence)::Bool
+
+Returns `true`. A [`LocalForbiddenSequence`](@ref) constraint is anti-monotone: if the forbidden
+vertical sequence of rules is already present along the constrained path, no completion can
+remove those nodes, so the violation persists in all completions.
+"""
+isantimonotone(::LocalForbiddenSequence) = true
+
+"""
     shouldschedule(::Solver, constraint::LocalForbiddenSequence, path::Vector{Int})::Bool
 
 Return true iff the manipulation happened at or above the constraint path.

--- a/src/localconstraints/local_ordered.jl
+++ b/src/localconstraints/local_ordered.jl
@@ -10,6 +10,15 @@ mutable struct LocalOrdered <: AbstractLocalConstraint
 end
 
 """
+    isantimonotone(::LocalOrdered)::Bool
+
+Returns `true`. A [`LocalOrdered`](@ref) constraint is anti-monotone: once the variable
+assignments are fixed (no holes remain in the matched pattern) and the ordering is violated,
+filling further holes elsewhere in the tree cannot undo that violation.
+"""
+isantimonotone(::LocalOrdered) = true
+
+"""
     function propagate!(solver::Solver, c::LocalOrdered)
 
 Enforce that the [`VarNode`](@ref)s in the `tree` are in the specified `order`.

--- a/src/localconstraints/local_unique.jl
+++ b/src/localconstraints/local_unique.jl
@@ -11,6 +11,15 @@ struct LocalUnique <: AbstractLocalConstraint
     holes::Vector{AbstractHole}
 end
 
+"""
+    isantimonotone(::LocalUnique)::Bool
+
+Returns `true`. A [`LocalUnique`](@ref) constraint is anti-monotone: if the required rule
+already appears more than once at or below the constrained path, filling holes can only add
+further nodes, never remove existing ones, so the violation persists in all completions.
+"""
+isantimonotone(::LocalUnique) = true
+
 LocalUnique(path::Vector{Int}, rule::Int) = LocalUnique(path, rule, Vector{AbstractHole}())
 
 """


### PR DESCRIPTION
from @sebdumancic https://github.com/Herb-AI/HerbConstraints.jl/pull/126#issuecomment-4286977880:

> Two functions introduced to src/HerbConstraints.jl, both defaulting to false:
> 
>   - `ismonotone(c)` — if a partial tree satisfies the constraint, all completions also satisfy it.
>   - `isantimonotone(c)` — if a partial tree violates the constraint, all completions also violate it.
> 
> 
>   **Classification of the built-in constraints**
> 
> _Contains_:
>  - is monotone: yes
>  - is anti-monotone: false
>  - rationale: Once the required rule appears, completions can only add nodes, never remove them 
>  
> _ContainsSubtree_:
>  - is monotone: yes
>  - is anti-monotone: false
>  - rationale: Same reasoning as contains
>   
> 
> _Forbidden_:
>  - is monotone: false
>  - is anti-monotone: true
>  - rationale:  Once the forbidden pattern is matched, no completion can un-match it
> 
> 
> _ForbiddenSequence_:
>  - is monotone: false
>  - is anti-monotone: true
>  - rationale:  A forbidden vertical sequence already in the tree cannot be  undone by filling holes 
> 
> 
> _Ordered_:
>  - is monotone: false
>  - is anti-monotone: true
>  - rationale:  Once variable assignments are fixed and order is violated, further hole-filling elsewhere can't undo the violation
> 
> 
> _Unique_:
>  - is monotone: false
>  - is anti-monotone: true
>  - rationale:  A rule appearing more than once in a partial tree can only appear more often in completions  
> 
> 
>   **Local constraint counterparts**
> 
>   The same overrides were added for all six local constraint types (LocalContains, LocalContainsSubtree, LocalForbidden, LocalForbiddenSequence, LocalOrdered, LocalUnique) mirroring the grammar-level classifications.